### PR TITLE
Update data validation for publisher commentActions endpoint 

### DIFF
--- a/packages/backend-api/src/api/publisher/commentActions.ts
+++ b/packages/backend-api/src/api/publisher/commentActions.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+import { logger } from '@conversationai/moderator-backend-core';
 import {
   enqueue,
   ICommentActionData,
@@ -53,7 +53,7 @@ export function queueMainAction(name: IKnownTasks): express.RequestHandler {
       res.json({ status: 'success' });
       next();
     } catch (e) {
-      console.log(e)
+      logger.error(e);
     }
   };
 }

--- a/packages/backend-api/src/api/publisher/commentActions.ts
+++ b/packages/backend-api/src/api/publisher/commentActions.ts
@@ -20,34 +20,41 @@ import {
   IKnownTasks,
 } from '@conversationai/moderator-backend-queue';
 import * as express from 'express';
-import * as Joi from 'joi';
+import { commentActionSchema } from '../services/commentActions';
 import { dataSchema, validateRequest } from '../util/validation';
 
 export const STATUS_ACCEPTED = 'accepted';
 export const STATUS_REJECTED = 'rejected';
 
-const validateNumberSchema = validateRequest(dataSchema(Joi.number()));
+const validateCommentActionRequest = validateRequest(dataSchema(commentActionSchema));
 
 /**
  * Queues an approval or rejected action. Accepts array of comment ids, or a single comment id.
  */
 export function queueMainAction(name: IKnownTasks): express.RequestHandler {
-  return async (req, res, next) => {
-    const dataArray = Array.isArray(req.body.data) ? req.body.data : [req.body.data];
+  return async ({ body }, res, next) => {
+    try {
+      const dataArray = Array.isArray(body.data) ? body.data : [body.data];
 
-    for (const commentId of dataArray) {
-      const parsedCommentId = parseInt(commentId, 10);
+      for (const data of dataArray) {
+        const { userId, commentId } = data;
 
-      await enqueue<ICommentActionData>(name, {
-        commentId: parsedCommentId,
-        userId: req.user ? req.user.get('id') : null,
-        isBatchAction: false,
-        autoConfirmDecision: true,
-      }, req.body.runImmediately || false);
+        const parsedUserId = parseInt(userId, 10);
+        const parsedCommentId = parseInt(commentId, 10);
+
+        const isBatchAction = (dataArray.length > 1) ? true : false;
+        await enqueue<ICommentActionData>(name, {
+          commentId: parsedCommentId,
+          userId: parsedUserId,
+          isBatchAction,
+        }, body.runImmediately || false);
+      }
+
+      res.json({ status: 'success' });
+      next();
+    } catch (e) {
+      console.log(e)
     }
-
-    res.json({ status: 'success' });
-    next();
   };
 }
 
@@ -58,27 +65,27 @@ export function createPublisherCommentActionsService(): express.Router {
   });
 
   router.post('/reset',
-    validateNumberSchema,
+    validateCommentActionRequest,
     queueMainAction('resetComments'),
   );
 
   router.post('/approve',
-    validateNumberSchema,
+    validateCommentActionRequest,
     queueMainAction('acceptComments'),
   );
 
   router.post('/highlight',
-    validateNumberSchema,
+    validateCommentActionRequest,
     queueMainAction('highlightComments'),
   );
 
   router.post('/reject',
-    validateNumberSchema,
+    validateCommentActionRequest,
     queueMainAction('rejectComments'),
   );
 
   router.post('/defer',
-    validateNumberSchema,
+    validateCommentActionRequest,
     queueMainAction('deferComments'),
   );
 


### PR DESCRIPTION
## Description
There is a set of `/publisher/commentActions/:action` endpoints that we use to send comment decisions from CRNR to Moderator. It's basically the same as an `/api/commentActions/:action` endpoints, but it was split out at some point to insulate the publisher comment flow from other Moderator API changes. 

## Motivation and Context

When we switched from int IDs to string IDs, we updated the validation layer for the API commentActions endpoint, but not the publisher commentActions endpoint, which still requires number IDs (publisher version [here](https://github.com/conversationai/conversationai-moderator/blob/master/packages/backend-api/src/api/publisher/commentActions.ts#L29) vs regular api version [here](https://github.com/conversationai/conversationai-moderator/blob/master/packages/backend-api/src/api/services/commentActions.ts#L41-L46)). 

The other small change is to log errors for this endpoint. Right now they're swallowed and it makes debugging a little tricky.

## How Has This Been Tested?
I manually tested it by running the backend-api locally and posting a comment to the `/publisher/commentActions/approve` endpoint. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have added tests to cover my changes.