### PR TITLE
Upgrade to 1.0.3 and fix build

### DIFF
--- a/packages/backend-api/package.json
+++ b/packages/backend-api/package.json
@@ -3,7 +3,7 @@
   "description": "API Endpoints for OSMod",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "scripts": {
     "test": "npm run mocha",
     "test:watch": "npm run compile && npm run compile:watch | npm run mocha:watch",
@@ -23,11 +23,11 @@
     "node": "6.11.0"
   },
   "dependencies": {
-    "@conversationai/moderator-backend-core": "1.0.0",
-    "@conversationai/moderator-backend-queue": "1.0.0",
-    "@conversationai/moderator-config": "1.0.0",
-    "@conversationai/moderator-frontend-web": "1.0.0",
-    "@conversationai/moderator-jsonapi": "1.0.0",
+    "@conversationai/moderator-backend-core": "1.0.3",
+    "@conversationai/moderator-backend-queue": "1.0.3",
+    "@conversationai/moderator-config": "1.0.3",
+    "@conversationai/moderator-frontend-web": "1.0.3",
+    "@conversationai/moderator-jsonapi": "1.0.3",
     "@types/bluebird": "3.5.2",
     "@types/express": "4.0.35",
     "@types/joi": "10.0.1",

--- a/packages/backend-api/src/test/test_helper.ts
+++ b/packages/backend-api/src/test/test_helper.ts
@@ -41,7 +41,7 @@ import {
 const TEST_ENVS = ['test', 'circle_ci'];
 
 function isTestEnv() {
-  return TEST_ENVS.indexOf(process.env.NODE_ENV) > -1;
+  return TEST_ENVS.indexOf(process.env.NODE_ENV || '') > -1;
 }
 
 logger.setTestMode(isTestEnv());

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@conversationai/moderator-backend-core",
   "description": "Shared Domain logic and models for OSMod",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
@@ -20,7 +20,7 @@
     "node": "6.11.0"
   },
   "dependencies": {
-    "@conversationai/moderator-config": "1.0.0",
+    "@conversationai/moderator-config": "1.0.3",
     "@types/bluebird": "3.5.2",
     "@types/express": "4.0.35",
     "@types/joi": "10.0.1",

--- a/packages/backend-core/src/test/test_helper.ts
+++ b/packages/backend-core/src/test/test_helper.ts
@@ -19,7 +19,7 @@ import { Comment, sequelize } from '../index';
 const TEST_ENVS = ['test', 'circle_ci'];
 
 function isTestEnv() {
-  return TEST_ENVS.indexOf(process.env.NODE_ENV) > -1;
+  return TEST_ENVS.indexOf(process.env.NODE_ENV || '') > -1;
 }
 
 function cleanDatabase(done: any) {

--- a/packages/backend-queue/package.json
+++ b/packages/backend-queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/moderator-backend-queue",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Task Queue for OSMod project",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -19,8 +19,8 @@
     "node": "6.11.0"
   },
   "dependencies": {
-    "@conversationai/moderator-backend-core": "1.0.0",
-    "@conversationai/moderator-config": "1.0.0",
+    "@conversationai/moderator-backend-core": "1.0.3",
+    "@conversationai/moderator-config": "1.0.3",
     "@types/express": "4.0.35",
     "@types/joi": "10.4.0",
     "@types/kue": "0.11.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@conversationai/moderator-cli",
   "description": "Commands for OSMod",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "scripts": {
     "lint": "find commands -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json",
     "lint:fix": "find commands -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json --fix",
@@ -17,8 +17,8 @@
     "node": "6.11.0"
   },
   "dependencies": {
-    "@conversationai/moderator-backend-core": "1.0.0",
-    "@conversationai/moderator-config": "1.0.0",
+    "@conversationai/moderator-backend-core": "1.0.3",
+    "@conversationai/moderator-config": "1.0.3",
     "@types/axios": "0.14.0",
     "@types/js-yaml": "3.5.29",
     "@types/lodash": "4.14.58",

--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/moderator-frontend-web",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "main": "dist-commonjs/index.js",
   "types": "./dist-commonjs/index.d.ts",
   "description": "OSMod project React.js frontend",
@@ -30,8 +30,8 @@
     "verbose": true
   },
   "dependencies": {
-    "@conversationai/moderator-config": "1.0.0",
-    "@conversationai/moderator-jsonapi": "1.0.0",
+    "@conversationai/moderator-config": "1.0.3",
+    "@conversationai/moderator-jsonapi": "1.0.3",
     "@types/express": "4.0.35",
     "@types/faker": "4.1.0",
     "express": "4.15.2",
@@ -40,7 +40,7 @@
     "typed-immutable-record": "0.0.6"
   },
   "devDependencies": {
-    "@conversationai/moderator-backend-core": "1.0.0",
+    "@conversationai/moderator-backend-core": "1.0.3",
     "@kadira/storybook": "2.35.3",
     "@types/aphrodite": "0.5.5",
     "@types/axios": "0.14.0",

--- a/packages/frontend-web/src/server.ts
+++ b/packages/frontend-web/src/server.ts
@@ -39,13 +39,13 @@ export function mountWebFrontend(modifyOutput?: (output: string) => string): App
       name = process.env.APP_NAME;
     }
 
-    let reasonToReject = true;
+    let reasonToReject = 'true';
 
     if (process.env.REQUIRE_REASON_TO_REJECT) {
-      reasonToReject = process.env.REQUIRE_REASON_TO_REJECT;
+      reasonToReject = (process.env.REQUIRE_REASON_TO_REJECT);
     }
 
-    let restrictToSession = true;
+    let restrictToSession = 'true';
 
     if (process.env.RESTRICT_TO_SESSION) {
       restrictToSession = process.env.RESTRICT_TO_SESSION;
@@ -63,7 +63,7 @@ export function mountWebFrontend(modifyOutput?: (output: string) => string): App
       submitFeedbackUrl = process.env.SUBMIT_FEEDBACK_URL;
     }
 
-    let commentsEditableFlag = true;
+    let commentsEditableFlag = 'true';
     if (process.env.COMMENTS_EDITABLE_FLAG) {
       commentsEditableFlag = process.env.COMMENTS_EDITABLE_FLAG;
     }

--- a/packages/jsonapi/package.json
+++ b/packages/jsonapi/package.json
@@ -3,7 +3,7 @@
   "description": "JSONAPI implementation for OSMod",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "scripts": {
     "lint": "find src -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json",
     "lint:fix": "find src -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json --fix",


### PR DESCRIPTION
## Description
This change upgrades the package.json files to use version 1.0.3 of the conversation-ai modules. I also noticed the build was breaking because of some typescript errors, so I fixed those here as well. 

## Motivation and Context
I want to publish version 1.0.4, but the local build was broken. 

## How Has This Been Tested?
I ran the build locally and it was successful. You can do the same by running `bin/install`. 

## Screenshots (if appropriate):
<img width="479" alt="screen shot 2017-07-14 at 11 09 37 am" src="https://user-images.githubusercontent.com/3289244/28217935-f8e4ae5c-6884-11e7-84f9-a0601139d6bb.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.