### PR TITLE
Bump version to 1.0.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "lerna": "2.0.0-beta.38",
-  "version": "1.0.0"
+  "version": "1.0.4"
 }

--- a/packages/backend-api/package.json
+++ b/packages/backend-api/package.json
@@ -3,7 +3,7 @@
   "description": "API Endpoints for OSMod",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "test": "npm run mocha",
     "test:watch": "npm run compile && npm run compile:watch | npm run mocha:watch",
@@ -23,11 +23,11 @@
     "node": "6.11.0"
   },
   "dependencies": {
-    "@conversationai/moderator-backend-core": "1.0.3",
-    "@conversationai/moderator-backend-queue": "1.0.3",
+    "@conversationai/moderator-backend-core": "1.0.4",
+    "@conversationai/moderator-backend-queue": "1.0.4",
     "@conversationai/moderator-config": "1.0.3",
-    "@conversationai/moderator-frontend-web": "1.0.3",
-    "@conversationai/moderator-jsonapi": "1.0.3",
+    "@conversationai/moderator-frontend-web": "1.0.4",
+    "@conversationai/moderator-jsonapi": "1.0.4",
     "@types/bluebird": "3.5.2",
     "@types/express": "4.0.35",
     "@types/joi": "10.0.1",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@conversationai/moderator-backend-core",
   "description": "Shared Domain logic and models for OSMod",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/backend-queue/package.json
+++ b/packages/backend-queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/moderator-backend-queue",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Task Queue for OSMod project",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -19,7 +19,7 @@
     "node": "6.11.0"
   },
   "dependencies": {
-    "@conversationai/moderator-backend-core": "1.0.3",
+    "@conversationai/moderator-backend-core": "1.0.4",
     "@conversationai/moderator-config": "1.0.3",
     "@types/express": "4.0.35",
     "@types/joi": "10.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@conversationai/moderator-cli",
   "description": "Commands for OSMod",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "lint": "find commands -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json",
     "lint:fix": "find commands -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json --fix",
@@ -17,7 +17,7 @@
     "node": "6.11.0"
   },
   "dependencies": {
-    "@conversationai/moderator-backend-core": "1.0.3",
+    "@conversationai/moderator-backend-core": "1.0.4",
     "@conversationai/moderator-config": "1.0.3",
     "@types/axios": "0.14.0",
     "@types/js-yaml": "3.5.29",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@conversationai/moderator-config",
   "description": "Shared Config logic for OSMod",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "main": "index.js",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversationai/moderator-frontend-web",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist-commonjs/index.js",
   "types": "./dist-commonjs/index.d.ts",
   "description": "OSMod project React.js frontend",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@conversationai/moderator-config": "1.0.3",
-    "@conversationai/moderator-jsonapi": "1.0.3",
+    "@conversationai/moderator-jsonapi": "1.0.4",
     "@types/express": "4.0.35",
     "@types/faker": "4.1.0",
     "express": "4.15.2",
@@ -40,7 +40,7 @@
     "typed-immutable-record": "0.0.6"
   },
   "devDependencies": {
-    "@conversationai/moderator-backend-core": "1.0.3",
+    "@conversationai/moderator-backend-core": "1.0.4",
     "@kadira/storybook": "2.35.3",
     "@types/aphrodite": "0.5.5",
     "@types/axios": "0.14.0",

--- a/packages/jsonapi/package.json
+++ b/packages/jsonapi/package.json
@@ -3,7 +3,7 @@
   "description": "JSONAPI implementation for OSMod",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "lint": "find src -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json",
     "lint:fix": "find src -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json --fix",


### PR DESCRIPTION
## Description
I published version 1.0.4 of all the conversationai-moderator modules to npm, but I didn't update the imports in the source code. 

## Motivation and Context
When you publish a new vesion with Lerna, it will automatically change your source code to import the new version of the modules. But then you need to remember to make a PR to commit those changes, which I did not. 

## How Has This Been Tested?
We're running 1.0.4 in prod at The Times. 


