### PR TITLE
Update frontend validation for articleId to allow for alphanumeric ids

### DIFF
--- a/packages/frontend-web/src/app/main.tsx
+++ b/packages/frontend-web/src/app/main.tsx
@@ -41,6 +41,7 @@ import { reducer as scenesReducer, scenes as makeRoutes } from './scenes';
 import { Login } from './scenes/Login';
 import { reducer as globalReducer } from './stores';
 import { clearReturnURL, getReturnURL } from './util';
+import { validateID } from './util/dataService';
 
 // Attach fastclick event handlers
 attachFastClick.attach(document.body);
@@ -96,7 +97,7 @@ export function startHistoryListener() {
               if (!key.endsWith('Id')) { return; }
               if (['all', 'deferred', 'assignments'].indexOf(params[key]) !== -1) { return; }
 
-              if (!params[key].match(/^[a-z0-9_\-]+$/) || 'number' !== typeof parseInt(params[key], 10)) {
+              if (validateID(params[key], 'articleId') || 'number' !== typeof parseInt(params[key], 10)) {
                 throw new Error(`Found an unparse-able id in the URL (${key} = ${params[key]}). Might be an attempted exploit.`);
               }
             });

--- a/packages/frontend-web/src/app/main.tsx
+++ b/packages/frontend-web/src/app/main.tsx
@@ -96,7 +96,7 @@ export function startHistoryListener() {
               if (!key.endsWith('Id')) { return; }
               if (['all', 'deferred', 'assignments'].indexOf(params[key]) !== -1) { return; }
 
-              if (!params[key].match(/^\d+$/) || 'number' !== typeof parseInt(params[key], 10)) {
+              if (!params[key].match(/^[a-z0-9_\-]+$/) || 'number' !== typeof parseInt(params[key], 10)) {
                 throw new Error(`Found an unparse-able id in the URL (${key} = ${params[key]}). Might be an attempted exploit.`);
               }
             });

--- a/packages/frontend-web/src/app/util/dataService.ts
+++ b/packages/frontend-web/src/app/util/dataService.ts
@@ -75,7 +75,16 @@ function validateModelName(name: string): void {
 }
 
 function validateID(id: any, valueName: string): void {
-  if (isNaN(parseInt(id, 10))) {
+  // We allow articleIds to be non-numeric so they can be the same as the publisher's
+  // upstream asset ids
+  if (valueName == "articleId") {
+    // a legal id contains only alphanumeric characters, hyphens or dashes
+    if (/^[a-z0-9_\-]+$/i.test(id) == false) {
+      throw new Error(`Invalid ${valueName} ${id}. Only alphanumeric characters, dashes and underscores are allowed in ${valueName}. Might be an attempted exploit.`)
+    }
+
+  // All other ids must be integers
+  } else if (isNaN(parseInt(id, 10))) {
     throw new Error(`Invalid ${valueName} (${parseInt(id, 10)} typeof ${typeof id}) was not a number as expected. Might be an attempted exploit.`);
   }
 }
@@ -147,7 +156,8 @@ function listURL(type: IValidModelNames, params?: Partial<IParams>): string {
 function modelURL(type: IValidModelNames, id: string, params?: Partial<IParams>): string {
   validateModelName(type);
 
-  return `${listURL(type)}/${parseInt(id, 10)}${serializeParams(params)}`;
+  return `${listURL(type)}/${id}${serializeParams(params)}`;
+
 }
 
 /**
@@ -216,7 +226,8 @@ export async function listHistogramScoresByArticle(
   validateID(tagId, `tagId`);
 
   const response: any = await axios.get(
-    serviceURL('histogramScores', `/articles/${parseInt(articleId, 10)}/tags/${parseInt(tagId, 10)}`, { sort }),
+    serviceURL('histogramScores', `/articles/${articleId}/tags/${parseInt(tagId, 10)}`, { sort }),
+
   );
 
   return List(
@@ -231,7 +242,8 @@ export async function listMaxSummaryScoreByArticle(
   validateID(articleId, `articleId`);
 
   const response: any = await axios.get(
-    serviceURL('histogramScores', `/articles/${parseInt(articleId, 10)}/summaryScore`, { sort }),
+    serviceURL('histogramScores', `/articles/${articleId}/summaryScore`, { sort }),
+
   );
 
   return List(
@@ -246,7 +258,8 @@ export async function listHistogramScoresByArticleByDate(
   validateID(articleId, `articleId`);
 
   const response: any = await axios.get(
-    serviceURL('histogramScores', `/articles/${parseInt(articleId, 10)}/byDate`, { sort }),
+    serviceURL('histogramScores', `/articles/${articleId}/byDate`, { sort }),
+
   );
 
   return List(
@@ -570,7 +583,7 @@ export async function getModeratedCommentIdsForArticle(
   validateID(articleId, `articleId`);
 
   const { data }: any = await axios.get(
-    serviceURL('moderatedCounts', `/articles/${parseInt(articleId, 10)}`, { sort }),
+    serviceURL('moderatedCounts', `/articles/${articleId}`, { sort }),
   );
 
   return data.data;

--- a/packages/frontend-web/src/app/util/dataService.ts
+++ b/packages/frontend-web/src/app/util/dataService.ts
@@ -74,11 +74,10 @@ function validateModelName(name: string): void {
   }
 }
 
-function validateID(id: any, valueName: string): void {
-  // We allow articleIds to be non-numeric so they can be the same as the publisher's
-  // upstream asset ids
+export function validateID(id: any, valueName: string): void {
+  // Article ids are can be non-numeric to allow for flexibility with matching upstream publisher article ids
   if (valueName == "articleId") {
-    // a legal id contains only alphanumeric characters, hyphens or dashes
+    // A legal id contains only alphanumeric characters, hyphens or dashes
     if (/^[a-z0-9_\-]+$/i.test(id) == false) {
       throw new Error(`Invalid ${valueName} ${id}. Only alphanumeric characters, dashes and underscores are allowed in ${valueName}. Might be an attempted exploit.`)
     }


### PR DESCRIPTION
## Description
It's become useful for us to keep the `articleID` in the Moderator database the same as the upstream `articleID` in our publisher/legacy system. Even though all the ids are strings now, the legacy `articleId`'s are alphanumeric and don't pass the Moderator frontend validation checks.

## Motivation and Context
This change updates the validation logic for the frontend to allow characters that are alphanumeric or dashes/underscores in for articleIds. 

## How Has This Been Tested?
I have run this version of the frontend against a backend pointing at our database and was able to load articles with no errors. Injecting funky characters into the `articleId` field does result in the app yelling at you, as expected. 

@mreifman To test, run `PORT=8080 API_URL=https://comments-api.dev.nyt.net  npm run watch` from the `frontend-web` package of this repo.  You should be able to run the frontend locally, pointing at dev and load articles like `http://localhost:8000/#/articles/article_100000005131930/new/SUMMARY_SCORE`.

## Screenshots
<img width="997" alt="screen shot 2017-09-06 at 4 30 56 pm" src="https://user-images.githubusercontent.com/3289244/30133166-dc846b14-9320-11e7-9671-06bc7dcdd113.png">

## Types o  changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)