### PR TITLE
Fix bug where settings page ids are set to ints

### DIFF
--- a/packages/frontend-web/src/app/scenes/Settings/Settings.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/Settings.tsx
@@ -480,7 +480,7 @@ export class Settings extends React.Component<ISettingsProps, ISettingsState> {
   }
 
   @autobind
-  handleAutomatedRuleChange(category: string, rule: IRuleModel, value: number) {
+  handleAutomatedRuleChange(category: string, rule: IRuleModel, value: number | string) {
     this.setState({
       rules: this.state.rules.update(
         this.state.rules.findIndex((r) => r.equals(rule)),
@@ -507,7 +507,7 @@ export class Settings extends React.Component<ISettingsProps, ISettingsState> {
   }
 
   @autobind
-  handleTaggingSensitivityChange(category: string, ts: ITaggingSensitivityModel, value: number) {
+  handleTaggingSensitivityChange(category: string, ts: ITaggingSensitivityModel, value: number | string) {
     this.setState({
       taggingSensitivities: this.state.taggingSensitivities.update(
         this.state.taggingSensitivities.findIndex((r) => r.equals(ts)),
@@ -525,7 +525,7 @@ export class Settings extends React.Component<ISettingsProps, ISettingsState> {
   }
 
   @autobind
-  handlePreselectChange(category: string, preselect: IPreselectModel, value: number) {
+  handlePreselectChange(category: string, preselect: IPreselectModel, value: number | string) {
     this.setState({
       preselects: this.state.preselects.update(
         this.state.preselects.findIndex((r) => r.equals(preselect)),

--- a/packages/frontend-web/src/app/scenes/Settings/components/RuleRow/RuleRow.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/RuleRow/RuleRow.tsx
@@ -101,8 +101,8 @@ export interface IRuleRowProps {
   selectedCategory: string;
   selectedTag?: string;
   onDelete?(rule: IRuleModel | ITaggingSensitivityModel | IPreselectModel): any;
-  onCategoryChange?(value: number): any;
-  onTagChange?(value: number): any;
+  onCategoryChange?(value: string): any;
+  onTagChange?(value: string): any;
   onLowerThresholdChange?(value: number): any;
   onUpperThresholdChange?(value: number): any;
   rule: IRuleModel | ITaggingSensitivityModel | IPreselectModel;
@@ -117,9 +117,9 @@ export class RuleRow extends React.Component<IRuleRowProps, void> {
   }
 
   @autobind
-  onCategoryFieldChange(callback: ((value: number) => any), e: React.ChangeEvent<HTMLSelectElement>) {
+  onCategoryFieldChange(callback: ((value: string) => any), e: React.ChangeEvent<HTMLSelectElement>) {
     e.preventDefault();
-    callback(parseInt(e.target.value, 10));
+    callback(e.target.value);
   }
 
   render() {


### PR DESCRIPTION
## Description
This is a small bug fix resulting from the change that switched all IDs from ints to strings. 

## Motivation and Context
The settings page loads data for moderation rules, preselects and tagging sensitivities from the JSON API rest endpoints that returns string `tagId`'s and `categoryId`'s. But when a new moderation rule, preselect or tagging sensitivity is added, the frontend POSTs a payload that looks like this:

```json
{
  "data":{
    "attributes": {
      "id": null,
      "action": null,
      "categoryId": 23,
      "createdBy": null,
      "lowerThreshold": 0.65,
      "upperThreshold": 1,
      "tagId": 2
    },
  "type": "tagging_sensitivities",
  "id":"1"
  }
}
```

Note the integer `categoryId` and `tagId` fields. Turns out the problem is that we explicitly cast those fields to integers whenever they are updated in the Redux store. 

## How Has This Been Tested?
Yes. @mreifman to test, run this version of the frontend against our dev Moderator API. `PORT=8080 API_URL=https://comments-api.dev.nyt.net npm run watch` from the frontend-web package. You can load the settings page, update a moderation rule, save the update and see that the data POST'ed back to the server is correctly typed. 

## Screenshots 
**before**
![screen shot 2017-09-07 at 8 21 52 pm](https://user-images.githubusercontent.com/3289244/30190726-360d3028-940a-11e7-8847-64970bbabedc.png)

**after**
![screen shot 2017-09-07 at 8 19 49 pm](https://user-images.githubusercontent.com/3289244/30190698-f527cde8-9409-11e7-8a94-2f5bd260dcff.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.