### PR TITLE
Fix category-level assignment bug 

### DIFF
--- a/packages/frontend-web/src/app/stores/moderators.ts
+++ b/packages/frontend-web/src/app/stores/moderators.ts
@@ -249,7 +249,7 @@ export function updateCategoryModerators(category: ICategoryModel, moderators: A
     const removedModeratorIds = getCategoryModeratorIds(getState())
         .toArray().filter((id) => !moderatorIds.some((modId) => modId === id));
 
-    if (typeof(category.id) === 'number') {
+    if (typeof(parseInt(category.id)) === 'number') {
       // post to service that adds/removes moderators to all articles for the category
       await updateCategoryAssignments(category.id, moderatorIds);
       // Go update state for the articles.


### PR DESCRIPTION
## Description
We allow users to be assigned to an article and a category. Article assignments are working, but category assignments have been broken since the switch from using integers to strings for resource ids. 

This is what the category assignment feature looks like:

![screen shot 2017-09-21 at 12 43 00 pm](https://user-images.githubusercontent.com/3289244/30707733-6cb3a9b6-9eca-11e7-9628-f8970c869426.png)

## Motivation and Context
This change fixes category assignments. The problem was that we were checking if the `categoryId` was of type `number`. We need to check if the `categoryId` can be parsed to be a number. 

## How Has This Been Tested?
I've tested this by running the frontend locally and pointing at a hosted backend. I was able to assign users to categories. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)