### PR TITLE
Adds parentheses to enable a ref null-check

### DIFF
--- a/packages/frontend-web/src/app/scenes/Comments/components/NewComments/NewComments.tsx
+++ b/packages/frontend-web/src/app/scenes/Comments/components/NewComments/NewComments.tsx
@@ -789,7 +789,7 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
             <p {...css(STYLES.commentsNotFoundMessaging)}>{commentsMessaging}</p>
           ) : (
             <CommentList
-              ownerHeight={window.innerHeight - this.listContainerRef && this.listContainerRef.getBoundingClientRect().top}
+              ownerHeight={window.innerHeight - (this.listContainerRef && this.listContainerRef.getBoundingClientRect().top)}
               heightOffset={HEADER_HEIGHT - ACTION_BAR_HEIGHT_FIXED + 5}
               textSizes={textSizes}
               commentIds={commentIds}


### PR DESCRIPTION
## Description
Fixes a conditional statement that sometimes led to a JavaScript error that broke the page:

```
NewComments.tsx:792 Uncaught (in promise) TypeError: Cannot read property 'getBoundingClientRect' of null
    at ve.render (NewComments.tsx:792)
    at se._renderValidatedComponentWithoutOwnerOrContext (ReactCompositeComponent.js:811)
    at se._renderValidatedComponent (ReactCompositeComponent.js:823)
    at se.performInitialMount (ReactCompositeComponent.js:365)
    at se.mountComponent (ReactCompositeComponent.js:258)
    at Object.mountComponent (ReactReconciler.js:46)
    at se.performInitialMount (ReactCompositeComponent.js:371)
    at se.mountComponent (ReactCompositeComponent.js:258)
    at Object.mountComponent (ReactReconciler.js:46)
    at se.performInitialMount (ReactCompositeComponent.js:371)
```

The null-check for the element reference needs to be wrapped together with the call to get it's height. I.e., we want the former here:

![screen shot 2018-01-12 at 11 07 11 am](https://user-images.githubusercontent.com/2730338/34883822-cc14d9e0-f788-11e7-90f9-dcbe24cf65b7.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
New comment list pages load as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.