### PR TITLE
Rufus hamade maintenance fixes 4

### DIFF
--- a/bin/watch
+++ b/bin/watch
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 cd packages/backend-api
-PORT=8080 REDIRECT_OAUTH_TO="referrer" WORKER_RUN_IMMEDIATELY="true" DEBUG_PORT=5859 npm run watch &
+npm run watch &
 cd -
 
 sleep 5
 
 cd packages/frontend-web
-PORT=8000 API_URL="http://localhost:8080" npm run watch &
+npm run watch &
 cd -
 
 wait

--- a/package-lock.json
+++ b/package-lock.json
@@ -3237,9 +3237,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "tslib": "1.7.1",
     "tslint": "5.3.2",
     "tslint-react": "3.0.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.3"
   }
 }

--- a/packages/backend-api/package.json
+++ b/packages/backend-api/package.json
@@ -12,7 +12,7 @@
     "start": "node ./server.js",
     "lint": "find src -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json",
     "lint:fix": "find src -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json --fix",
-    "watch": "npm run compile && npm run compile:watch | npm run server",
+    "watch": "npm run compile && npm run compile:watch | PORT=8080 DEBUG_PORT=5859 npm run server",
     "compile": "rm -rf dist && ../../node_modules/.bin/tsc --sourceMap --outDir dist --declaration",
     "compile:watch": "../../node_modules/.bin/tsc --watch --sourceMap --outDir dist --declaration",
     "build": "npm run compile",

--- a/packages/backend-api/src/api/services/assignments.ts
+++ b/packages/backend-api/src/api/services/assignments.ts
@@ -58,7 +58,7 @@ export function createAssignmentsService(): express.Router {
 
   router.get('/users/:id/count', async (req, res, next) => {
     const user = await User.findById(req.params.id);
-    const count = await user.countAssignments();
+    const count = user ? await user.countAssignments() : 0;
 
     // So simple, not worth validating the schema.
     res.json({ count });

--- a/packages/backend-api/src/api/services/authorCounts.ts
+++ b/packages/backend-api/src/api/services/authorCounts.ts
@@ -43,15 +43,8 @@ export interface IAuthorCounts {
 }
 
 export async function getAuthorCounts(authorSourceId: string): Promise<IAuthorCounts> {
-  const [approvedCount, rejectedCount] = await Promise.all([
-
-    // approved
-    Comment.count({ where: { authorSourceId, isAccepted: true } }),
-
-    // rejected
-    Comment.count({ where: { authorSourceId, isAccepted: false } }),
-
-  ]);
+  const approvedCount = await Comment.count({ where: { authorSourceId, isAccepted: true } });
+  const rejectedCount = await Comment.count({ where: { authorSourceId, isAccepted: false } });
 
   return {
     approvedCount,

--- a/packages/backend-api/src/api/services/updateNotifications.ts
+++ b/packages/backend-api/src/api/services/updateNotifications.ts
@@ -84,7 +84,7 @@ async function getGlobalSummary() {
 }
 
 async function getUserSummary(userId: number) {
-  const user = await User.findById(userId);
+  const user = (await User.findById(userId))!;
   const assignments = await user.countAssignments();
 
   return {

--- a/packages/backend-api/src/test/integration/api/assignments.spec.ts
+++ b/packages/backend-api/src/test/integration/api/assignments.spec.ts
@@ -23,7 +23,9 @@ import {
 import {
   Article,
   Category,
+  Comment,
   ModeratorAssignment,
+  User,
   UserCategoryAssignment,
 } from '@conversationai/moderator-backend-core';
 
@@ -42,17 +44,18 @@ const BASE_URL = `/services/assignments`;
 
 describe(BASE_URL, () => {
   beforeEach(async () => {
+    await ModeratorAssignment.destroy({where: {}});
+    await UserCategoryAssignment.destroy({where: {}});
+    await Comment.destroy({where: {}});
+    await Article.destroy({where: {}});
+    await Category.destroy({where: {}});
+    await User.destroy({where: {}});
+
     this.category = await makeCategory();
     this.article = await makeArticle({categoryId: this.category.id});
     await makeComment({articleId: this.article.id});
     denormalizeCommentCountsForArticle(this.article);
     this.user = await makeUser();
-  });
-
-  afterEach (async () => {
-    await ModeratorAssignment.destroy({where: {}});
-    await Article.destroy({where: {}});
-    await Category.destroy({where: {}});
   });
 
   describe('/users/:id/count', () => {

--- a/packages/backend-api/src/test/integration/api/assistant.spec.ts
+++ b/packages/backend-api/src/test/integration/api/assistant.spec.ts
@@ -17,9 +17,12 @@ limitations under the License.
 import * as chai from 'chai';
 
 import {
+  Comment,
   CommentScoreRequest,
   sequelize,
+  User,
 } from '@conversationai/moderator-backend-core';
+
 import {
   expect,
   makeComment,
@@ -37,6 +40,8 @@ describe(prefixed, () => {
 
   describe('/scores/:id', () => {
     beforeEach(async () => {
+      await Comment.destroy({where: {}});
+      await User.destroy({where: {}});
       const comment = await makeComment();
       const user = await makeUser();
 

--- a/packages/backend-api/src/test/integration/api/authorCounts.spec.ts
+++ b/packages/backend-api/src/test/integration/api/authorCounts.spec.ts
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import * as chai from 'chai';
+
+import {
+  Comment,
+} from '@conversationai/moderator-backend-core';
+
 import {
   expect,
   makeComment,
 } from '../../test_helper';
 import {
-  app
+  app,
 } from './test_helper';
-import * as chai from "chai";
 
 const BASE_URL = `/services/authorCounts`;
 
@@ -40,6 +45,9 @@ async function fakeAuthor(authorSourceId: string, approvedCount: number, rejecte
 }
 
 describe(BASE_URL, () => {
+  beforeEach(async () => {
+    await Comment.destroy({where: {}});
+  });
 
   describe('/authorCounts', () => {
 

--- a/packages/backend-api/src/test/integration/api/editComment.spec.ts
+++ b/packages/backend-api/src/test/integration/api/editComment.spec.ts
@@ -13,6 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import * as chai from "chai";
+
+import {
+  Comment,
+} from '@conversationai/moderator-backend-core';
 
 import {
   expect,
@@ -22,11 +27,6 @@ import {
 import {
   app,
 } from './test_helper';
-
-import {
-  Comment,
-} from '@conversationai/moderator-backend-core';
-import * as chai from "chai";
 
 const URL = `/services/editComment`;
 
@@ -88,10 +88,10 @@ describe(URL, () => {
             });
 
             const updatedComment = await Comment.findOne({ where: { id: comment.id }});
-            const { name, location } = JSON.parse(updatedComment.get('author'));
+            const { name, location } = JSON.parse(updatedComment!.get('author'));
 
             expect(status).to.be.equal(200);
-            expect(updatedComment.get('text')).to.be.equal(updatedText);
+            expect(updatedComment!.get('text')).to.be.equal(updatedText);
             expect(name).to.be.equal(updatedAuthorName);
             expect(location).to.be.equal(updatedAuthorLocation);
 

--- a/packages/backend-api/src/test/integration/api/histogramScores.spec.ts
+++ b/packages/backend-api/src/test/integration/api/histogramScores.spec.ts
@@ -14,8 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { cacheCommentTopScores } from '@conversationai/moderator-backend-core';
 import * as chai from 'chai';
+
+import {
+  Article,
+  Category,
+  Comment,
+  CommentSummaryScore,
+  Tag,
+} from '@conversationai/moderator-backend-core';
+
+import { cacheCommentTopScores } from '@conversationai/moderator-backend-core';
+
 import {
   expect,
   makeArticle,
@@ -31,6 +41,13 @@ import {
 const BASE_URL = `/services/histogramScores`;
 
 describe(BASE_URL, () => {
+  beforeEach(async () => {
+    await CommentSummaryScore.destroy({where: {}});
+    await Comment.destroy({where: {}});
+    await Article.destroy({where: {}});
+    await Category.destroy({where: {}});
+    await Tag.destroy({where: {}});
+  });
 
   describe('/articles/:articleId/tags/:tagId', () => {
 

--- a/packages/backend-api/src/test/integration/api/publisher.spec.ts
+++ b/packages/backend-api/src/test/integration/api/publisher.spec.ts
@@ -15,8 +15,9 @@ limitations under the License.
 */
 
 import {
-  Article,
+  Article, Comment,
 } from '@conversationai/moderator-backend-core';
+
 import { createArticleIfNonExistant, IArticleData } from '../../../api/publisher/articles';
 import {
   expect,
@@ -65,8 +66,20 @@ describe('Publisher API', () => {
     return `${BASE_URL}/${path}`;
   }
 
-  describe(BASE_URL, () => {
+  function checkCreated(bodyData: any, ids: Array<string>) {
+    for (const i of ids) {
+      expect(bodyData[i]).to.be.an('string');
+      delete bodyData[i];
+    }
+    expect(bodyData).to.deep.equal({});
+  }
 
+  beforeEach(async () => {
+    await Comment.destroy({where: {}});
+    await Article.destroy({where: {}});
+  });
+
+  describe(BASE_URL, () => {
     describe('/articles', () => {
       const url = prefixed('articles');
 
@@ -83,9 +96,7 @@ describe('Publisher API', () => {
           expect(status).to.be.equal(200);
           was200 = true;
 
-          expect(body.data).to.deep.equal({
-            [validArticleData1.sourceId]: '1',
-          });
+          checkCreated(body.data, [validArticleData1.sourceId]);
         } finally {
           expect(was200).to.be.true;
         }
@@ -106,10 +117,7 @@ describe('Publisher API', () => {
           expect(status).to.be.equal(200);
           was200 = true;
 
-          expect(body.data).to.deep.equal({
-            [validArticleData1.sourceId]: '1',
-            [validArticleData2.sourceId]: '2',
-          });
+          checkCreated(body.data, [validArticleData1.sourceId, validArticleData2.sourceId]);
         } finally {
           expect(was200).to.be.true;
         }
@@ -132,10 +140,7 @@ describe('Publisher API', () => {
           expect(status).to.be.equal(200);
           was200 = true;
 
-          expect(body.data).to.deep.equal({
-            [validArticleData1.sourceId]: '2', // because number 2 was already inserted
-            [validArticleData2.sourceId]: '1',
-          });
+          checkCreated(body.data, [validArticleData1.sourceId, validArticleData2.sourceId]);
         } finally {
           expect(was200).to.be.true;
         }
@@ -247,9 +252,7 @@ describe('Publisher API', () => {
           expect(status).to.be.equal(200);
           was200 = true;
 
-          expect(body.data).to.deep.equal({
-            [commentData.sourceId]: '1',
-          });
+          checkCreated(body.data, [commentData.sourceId]);
         } finally {
           expect(was200).to.be.true;
         }
@@ -277,10 +280,7 @@ describe('Publisher API', () => {
           expect(status).to.be.equal(200);
           was200 = true;
 
-          expect(body.data).to.deep.equal({
-            [commentData1.sourceId]: '1',
-            [commentData2.sourceId]: '2',
-          });
+          checkCreated(body.data, [commentData1.sourceId, commentData2.sourceId]);
         } finally {
           expect(was200).to.be.true;
         }

--- a/packages/backend-api/src/test/integration/websocket/assign_moderators.spec.ts
+++ b/packages/backend-api/src/test/integration/websocket/assign_moderators.spec.ts
@@ -17,7 +17,8 @@ limitations under the License.
 import * as chai from 'chai';
 import * as WebSocket from 'ws';
 
-import { clearInterested, makeServer } from '@conversationai/moderator-backend-core';
+import {Article, Category, User} from '@conversationai/moderator-backend-core';
+import {clearInterested, makeServer} from '@conversationai/moderator-backend-core';
 
 import {destroyUpdateNotificationService} from '../../../api/services/updateNotifications';
 import {mountAPI} from '../../../index';
@@ -47,6 +48,10 @@ describe('websocket tests: assign moderators', () => {
   let article: any;
 
   beforeEach(async () => {
+    await Article.destroy({where: {}});
+    await Category.destroy({where: {}});
+    await User.destroy({where: {}});
+
     user = await makeUser();
 
     category = await makeCategory();

--- a/packages/backend-api/src/test/integration/websocket/websocket.spec.ts
+++ b/packages/backend-api/src/test/integration/websocket/websocket.spec.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as WebSocket from 'ws';
 
+import { User } from '@conversationai/moderator-backend-core';
 import { clearInterested, makeServer } from '@conversationai/moderator-backend-core';
 
 import {mountAPI} from '../../../index';
@@ -25,8 +26,11 @@ import {
   sleep,
 } from '../../test_helper';
 
-
 describe('websocket tests', () => {
+  beforeEach(async () => {
+    await User.destroy({where: {}});
+  });
+
   afterEach(clearInterested);
 
   it('Test what we get when connect without authentication', async () => {

--- a/packages/backend-api/src/test/test_helper.ts
+++ b/packages/backend-api/src/test/test_helper.ts
@@ -62,7 +62,6 @@ function dropDatabase(done: any) {
 }
 
 before(cleanDatabase);
-beforeEach(cleanDatabase);
 after(dropDatabase);
 
 const expect = chai.expect;

--- a/packages/backend-api/src/test/unit/services/authorCounts.spec.ts
+++ b/packages/backend-api/src/test/unit/services/authorCounts.spec.ts
@@ -15,6 +15,10 @@ limitations under the License.
 */
 
 import {
+  Comment,
+} from '@conversationai/moderator-backend-core';
+
+import {
   expect,
   makeComment,
 } from '../../test_helper';
@@ -24,6 +28,9 @@ import {
 } from '../../../api/services/authorCounts';
 
 describe('authorCounts Functions', () => {
+  beforeEach(async () => {
+    await Comment.destroy({where: {}});
+  });
 
   describe('getAuthorCounts', () => {
     it('should return 0 for unknown authors', async () => {

--- a/packages/backend-api/src/test/unit/services/histogramScores.spec.ts
+++ b/packages/backend-api/src/test/unit/services/histogramScores.spec.ts
@@ -17,8 +17,13 @@ limitations under the License.
 import { NotFoundError } from '@conversationai/moderator-jsonapi';
 
 import {
+  Article,
+  Category,
+  Comment,
+  CommentSummaryScore,
   IArticleInstance,
   ICategoryInstance,
+  Tag,
 } from '@conversationai/moderator-backend-core';
 
 import {
@@ -37,6 +42,13 @@ import {
 } from '../../../api/services/histogramScores/util';
 
 describe('histogramScores Functions', () => {
+  beforeEach(async () => {
+    await CommentSummaryScore.destroy({where: {}});
+    await Comment.destroy({where: {}});
+    await Article.destroy({where: {}});
+    await Category.destroy({where: {}});
+    await Tag.destroy({where: {}});
+  });
 
   describe('getHistogramScoresForAllCategories', () => {
     it('returns scores across all categories for tag', async () => {

--- a/packages/backend-api/src/test/unit/util/queryComments.spec.ts
+++ b/packages/backend-api/src/test/unit/util/queryComments.spec.ts
@@ -18,6 +18,9 @@ import {
   cacheCommentTopScores,
   calculateTopScores,
 } from '@conversationai/moderator-backend-core';
+import {
+  Article, Category, Comment, Tag
+} from '@conversationai/moderator-backend-core';
 
 import {
   expect,
@@ -36,6 +39,11 @@ import {
 describe('queryComments Functions', () => {
   describe('filterTopScoresByTaggingSensitivity', () => {
     beforeEach(async () => {
+      await Comment.destroy({where: {}});
+      await Article.destroy({where: {}});
+      await Category.destroy({where: {}});
+      await Tag.destroy({where: {}});
+
       this.category = await makeCategory({ label: 'Test' });
 
       const article = await makeArticle({ categoryId: this.category.id });

--- a/packages/backend-core/bin/check_migrations.sh
+++ b/packages/backend-core/bin/check_migrations.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Do a sequelize sync and dump the resulting schema:
+
+export DATABASE_NAME=os_moderator_schema_test_sync
+mysql -u root -p$DATABASE_PASSWORD << EOF
+DROP DATABASE IF EXISTS $DATABASE_NAME;
+CREATE DATABASE $DATABASE_NAME;
+GRANT ALL on $DATABASE_NAME.* to $DATABASE_USER;
+EOF
+
+node bin/run_sequelize_sync.js
+
+# Now do the same thing, but this time loading base database and running through
+# the migrations
+export DATABASE_NAME=os_moderator_schema_test_migrations
+mysql -u root -p$DATABASE_PASSWORD << EOF
+DROP DATABASE IF EXISTS $DATABASE_NAME;
+CREATE DATABASE $DATABASE_NAME;
+GRANT ALL on $DATABASE_NAME.* to $DATABASE_USER;
+EOF
+mysql -u root -p$DATABASE_PASSWORD $DATABASE_NAME < seed/initial-database.sql
+npx sequelize db:migrate --config ../config/sequelize.js --migrations-path dist/migrations --models-path dist/models
+
+
+mysql-schema-diff -u root -p=$DATABASE_PASSWORD os_moderator_schema_test_migrations os_moderator_schema_test_sync

--- a/packages/backend-core/bin/make_migration.sh
+++ b/packages/backend-core/bin/make_migration.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx sequelize migration:create --config ../config/sequelize.js --migrations-path src/migrations --name $1

--- a/packages/backend-core/bin/run_sequelize_sync.js
+++ b/packages/backend-core/bin/run_sequelize_sync.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+const { sequelize } = require('../dist');
+sequelize.sync({ force: true });

--- a/packages/backend-core/src/domain/comments/apiShim.ts
+++ b/packages/backend-core/src/domain/comments/apiShim.ts
@@ -22,7 +22,6 @@ const striptags = require('striptags');
 import { logger } from '../../logger';
 
 import {
-  Article,
   ICommentInstance,
   IUserInstance,
 } from '../../models';
@@ -104,10 +103,12 @@ export async function createShim(
       spanAnnotations: true,
     };
 
-    const article = await Article.findById(comment.get('articleId'));
-    req.context.entries.push({text: striptags(article.get('text'))});
+    const article = await comment.getArticle();
+    if (article) {
+      req.context.entries.push({text: striptags(article.get('text'))});
+    }
 
-    const replyTo = comment.get('replyTo');
+    const replyTo = await comment.getReplyTo();
     if (replyTo) {
       req.context.entries.push({text: striptags(replyTo.get('text'))});
     }

--- a/packages/backend-core/src/domain/comments/pipeline.ts
+++ b/packages/backend-core/src/domain/comments/pipeline.ts
@@ -74,7 +74,7 @@ export async function sendToScorer(comment: ICommentInstance, scorer: IUserInsta
 
     let shim = shims.get(scorer.id);
     if (!shim) {
-      const extra: any = JSON.parse(scorer.get('extra')); // TODO: Not sure why necessary.  Fixed in later Sequelize?
+      const extra: any = JSON.parse(scorer.get('extra'));
 
       if (extra.endpointType === ENDPOINT_TYPE_API) {
         shim = await createApiShim(scorer, processMachineScore);
@@ -296,7 +296,7 @@ export async function completeMachineScoring(commentId: number): Promise<void> {
   await cacheCommentTopScores(comment);
   await processRulesForComment(comment);
   await denormalizeCountsForComment(comment);
-  await denormalizeCommentCountsForArticle(comment.get('article'));
+  await denormalizeCommentCountsForArticle(await comment.getArticle());
 }
 
 /**

--- a/packages/backend-core/src/domain/comments/proxyShim.ts
+++ b/packages/backend-core/src/domain/comments/proxyShim.ts
@@ -121,10 +121,8 @@ export function createShim(
       };
 
       // Check for a `replyTo`
-
-      if (comment.get('replyTo')) {
-        const replyTo = comment.get('replyTo');
-
+      const replyTo = await comment.getReplyTo();
+      if (replyTo) {
         postData.inReplyToComment = {
           commentId: replyTo.id,
           plainText: striptags(replyTo.get('text')),

--- a/packages/backend-core/src/migrations/20180917130651-fix_minor_inconsistencies.js
+++ b/packages/backend-core/src/migrations/20180917130651-fix_minor_inconsistencies.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+  up: async function (queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      "ALTER TABLE last_updates ENGINE=InnoDB DEFAULT CHARSET=utf8;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+
+    await queryInterface.sequelize.query(
+      "ALTER TABLE articles DROP FOREIGN KEY categoryId_foreign_idx;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE articles DROP INDEX categoryId_foreign_idx;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE articles ADD INDEX categoryId (categoryId);",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE articles ADD CONSTRAINT articles_ibfk_1 FOREIGN KEY (categoryId) REFERENCES categories (id) ON DELETE SET NULL ON UPDATE CASCADE;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+
+    await queryInterface.sequelize.query(
+      "ALTER TABLE categories CHANGE COLUMN isActive isActive tinyint(1) DEFAULT '1';",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments CHANGE COLUMN isAutoResolved isAutoResolved tinyint(1) DEFAULT '0';",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments CHANGE COLUMN isHighlighted isHighlighted tinyint(1) DEFAULT '0';",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments CHANGE COLUMN isDeferred isDeferred tinyint(1) DEFAULT '0';",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments CHANGE COLUMN isBatchResolved isBatchResolved tinyint(1) DEFAULT '0';",
+        { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments ADD CONSTRAINT comments_ibfk_2 FOREIGN KEY (replyId) REFERENCES comments (id) ON DELETE SET NULL ON UPDATE CASCADE;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments DROP FOREIGN KEY comments_ibfk_1;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments DROP INDEX articleId_index;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments ADD INDEX articleId (articleId);",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+    await queryInterface.sequelize.query(
+      "ALTER TABLE comments ADD CONSTRAINT comments_ibfk_1 FOREIGN KEY (articleId) REFERENCES articles (id) ON DELETE SET NULL ON UPDATE CASCADE;",
+      { type: queryInterface.sequelize.QueryTypes.RAW });
+  },
+
+  down: function (queryInterface, Sequelize) {
+  }
+};

--- a/packages/backend-core/src/models/comment.ts
+++ b/packages/backend-core/src/models/comment.ts
@@ -63,6 +63,7 @@ export interface ICommentInstance extends Sequelize.Instance<ICommentAttributes>
   getArticle: Sequelize.BelongsToGetAssociationMixin<IArticleInstance>;
   getDecisions: Sequelize.HasManyGetAssociationsMixin<IDecisionInstance>;
   getCommentSummaryScores: Sequelize.HasManyGetAssociationsMixin<ICommentSummaryScoreInstance>;
+  getReplyTo: Sequelize.BelongsToGetAssociationMixin<ICommentInstance>;
 }
 
 /**

--- a/packages/backend-core/src/models/comment_flag.ts
+++ b/packages/backend-core/src/models/comment_flag.ts
@@ -18,6 +18,7 @@ import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
 
 export interface ICommentFlagAttributes {
+  id?: number;
   commentId: number;
   sourceId?: string;
   extra?: any;

--- a/packages/backend-core/src/models/comment_score.ts
+++ b/packages/backend-core/src/models/comment_score.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
+import { ITagInstance } from './tag';
 
 export const SCORE_SOURCE_TYPES = [
   'User',
@@ -43,6 +44,8 @@ export interface ICommentScoreInstance extends Sequelize.Instance<ICommentScoreA
   id: number;
   createdAt: string;
   updatedAt: string;
+
+  getTag: Sequelize.BelongsToGetAssociationMixin<ITagInstance>;
 }
 
 /**

--- a/packages/backend-core/src/models/comment_score_request.ts
+++ b/packages/backend-core/src/models/comment_score_request.ts
@@ -15,7 +15,9 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
+
 import { sequelize } from '../sequelize';
+import {ICommentInstance} from './comment';
 
 export interface ICommentScoreRequestAttributes {
   id?: number;
@@ -32,6 +34,7 @@ export interface ICommentScoreRequestInstance
   id: number;
   createdAt: string;
   updatedAt: string;
+  getComment: Sequelize.BelongsToGetAssociationMixin<ICommentInstance>;
 }
 
 /**

--- a/packages/backend-core/src/models/comment_summary_score.ts
+++ b/packages/backend-core/src/models/comment_summary_score.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
+import { ITagInstance } from './tag';
 
 export interface ICommentSummaryScoreAttributes {
   id?: number;
@@ -28,6 +29,7 @@ export interface ICommentSummaryScoreAttributes {
 
 export interface ICommentSummaryScoreInstance
     extends Sequelize.Instance<ICommentSummaryScoreAttributes> {
+  getTag: Sequelize.BelongsToGetAssociationMixin<ITagInstance>;
 }
 
 /**

--- a/packages/backend-core/src/models/csrf.ts
+++ b/packages/backend-core/src/models/csrf.ts
@@ -24,11 +24,10 @@ export interface ICSRFAttributes {
   referrer: string | null;
 }
 
-export interface ICSRFInstance
-    extends Sequelize.Instance<ICSRFAttributes> {
+export interface ICSRFInstance extends Sequelize.Instance<ICSRFAttributes> {
   id: number;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 /**

--- a/packages/backend-core/src/sequelize.ts
+++ b/packages/backend-core/src/sequelize.ts
@@ -20,6 +20,10 @@ import * as Sequelize from 'sequelize';
 
 const mysqlConfig: any = {
   dialect: 'mysql',
+  define: {
+    charset: 'utf8',
+    collate: 'utf8_general_ci',
+  },
   logging: false,
   host: undefined,
   port: undefined,

--- a/packages/backend-core/src/test/domain/auth/users.spec.ts
+++ b/packages/backend-core/src/test/domain/auth/users.spec.ts
@@ -30,6 +30,11 @@ const assert = chai.assert;
 // tslint:disable
 
 describe('Auth Domain Users Tests', function() {
+  beforeEach(async () => {
+    await UserSocialAuth.destroy({where:{}});
+    await User.destroy({where:{}});
+  });
+
   describe('isValidUser', function() {
     it('should return true for an active user', async () => {
       const activeUser = await User.create({

--- a/packages/backend-core/src/test/domain/comments/pipeline.spec.ts
+++ b/packages/backend-core/src/test/domain/comments/pipeline.spec.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { assert } from 'chai';
 import { groupBy } from 'lodash';
 import * as moment from 'moment';
+
 import {
   compileScoresData,
   compileSummaryScoresData,
@@ -183,26 +184,24 @@ describe('Comments Domain Pipeline Tests', () => {
       await completeMachineScoring(comment.id);
 
       // Get scores and score requests from the database
-      const [scores, request, summaryScores] = await Promise.all([
-        CommentScore.findAll({
+      const scores = await CommentScore.findAll({
           where: {
             commentId: comment.id,
           },
           include: [Tag],
-        }),
-        CommentScoreRequest.findOne({
+        });
+      const request = await CommentScoreRequest.findOne({
           where: {
             id: commentScoreRequest.id,
           },
           include: [Comment],
-        }),
-        CommentSummaryScore.findAll({
+        });
+      const summaryScores = await CommentSummaryScore.findAll({
           where: {
             commentId: comment.id,
           },
           include: [Tag],
-        }),
-      ]);
+        });
 
       // Scores assertions
       assert.lengthOf(scores, 3);
@@ -219,37 +218,37 @@ describe('Comments Domain Pipeline Tests', () => {
         if (score.get('score') === 0.2) {
           assert.equal(score.get('annotationStart'), 0);
           assert.equal(score.get('annotationEnd'), 62);
-          assert.equal(score.get('tag').get('key'), 'ATTACK_ON_COMMENTER');
+          assert.equal((await score.getTag())!.get('key'), 'ATTACK_ON_COMMENTER');
         }
 
         if (score.get('score') === 0.4) {
           assert.equal(score.get('annotationStart'), 0);
           assert.equal(score.get('annotationEnd'), 62);
-          assert.equal(score.get('tag').get('key'), 'INFLAMMATORY');
+          assert.equal((await score.getTag())!.get('key'), 'INFLAMMATORY');
         }
 
         if (score.get('score') === 0.7) {
           assert.equal(score.get('annotationStart'), 63);
           assert.equal(score.get('annotationEnd'), 66);
-          assert.equal(score.get('tag').get('key'), 'INFLAMMATORY');
+          assert.equal((await score.getTag())!.get('key'), 'INFLAMMATORY');
         }
       }
 
       for (const score of summaryScores) {
         if (score.get('score') === 0.2) {
-          assert.equal(score.get('tag').get('key'), 'ATTACK_ON_COMMENTER');
+          assert.equal((await score.getTag())!.get('key'), 'ATTACK_ON_COMMENTER');
         }
 
         if (score.get('score') === 0.55) {
-          assert.equal(score.get('tag').get('key'), 'INFLAMMATORY');
+          assert.equal((await score.getTag())!.get('key'), 'INFLAMMATORY');
         }
       }
 
       // Request assertions
-
-      assert.isOk(request.get('doneAt'));
-      assert.equal(request.get('commentId'), comment.id);
-      assert.isTrue(request.get('comment').get('isScored'));
+      assert.isNotNull(request);
+      assert.isOk(request!.get('doneAt'));
+      assert.equal(request!.get('commentId'), comment.id);
+      assert.isTrue((await request!.getComment())!.get('isScored'));
     });
 
     it('should short-circuit if error key is present and not falsy in the scoreData', async () => {
@@ -404,7 +403,7 @@ describe('Comments Domain Pipeline Tests', () => {
         }
       });
 
-      assert.isFalse(commentScoreRequests[0].get('comment').get('isScored'));
+      assert.isFalse((await commentScoreRequests[0].getComment())!.get('isScored'));
     });
   });
 

--- a/packages/backend-core/src/test/domain/comments/pipeline.spec.ts
+++ b/packages/backend-core/src/test/domain/comments/pipeline.spec.ts
@@ -30,7 +30,7 @@ import {
 import {
   IScores,
   ISummaryScores,
-} from '../../../domain/comments/shim';
+} from '../../../domain/comments';
 import {
   Article,
   Category,
@@ -41,7 +41,7 @@ import {
   Decision,
   Tag,
 } from '../../../models';
-import { ITagInstance } from '../../../models/tag';
+import { ITagInstance } from '../../../models';
 import {
   createArticle,
   createCategory,
@@ -56,10 +56,14 @@ import {
 
 describe('Comments Domain Pipeline Tests', () => {
   beforeEach(async () => {
-    await Tag.destroy({where: {}});
+    await CommentSummaryScore.destroy({where: {}});
+    await CommentScore.destroy({where: {}});
+    await CommentScoreRequest.destroy({where: {}});
+    await Decision.destroy({where: {}});
     await Comment.destroy({where: {}});
     await Article.destroy({where: {}});
     await Category.destroy({where: {}});
+    await Tag.destroy({where: {}});
   });
 
   describe('getCommentsToResendForScoring', () => {

--- a/packages/backend-core/src/test/domain/comments/rules.spec.ts
+++ b/packages/backend-core/src/test/domain/comments/rules.spec.ts
@@ -19,8 +19,10 @@ import {
   compileScores,
   processRulesForComment,
   resolveComment,
-} from '../../../domain/comments/rules';
+} from '../../../domain/comments';
 import {
+  Article,
+  Category,
   Comment,
   CommentSummaryScore,
   ModerationRule,
@@ -38,6 +40,15 @@ import {
 } from './fixture';
 
 describe('Comment Domain Rules Tests', () => {
+  beforeEach(async () => {
+    await CommentSummaryScore.destroy({where: {}});
+    await Comment.destroy({where: {}});
+    await ModerationRule.destroy({where: {}});
+    await Tag.destroy({where: {}});
+    await Article.destroy({where: {}});
+    await Category.destroy({where: {}});
+  });
+
   describe('compileScores', () => {
     it('should return an object of scores keyed by tag id', () => {
       const tag1 = Tag.build(getTagData());
@@ -110,7 +121,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isTrue(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -144,7 +156,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isTrue(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -273,7 +286,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -302,7 +316,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isFalse(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -344,7 +359,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isFalse(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -373,7 +389,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = (await Comment.findById(comment.id));
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -424,7 +441,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -479,7 +497,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -521,7 +540,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isTrue(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -569,7 +589,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'), 'isAccepted');
       assert.isTrue(updated.get('isAutoResolved'), 'isAutoResolved');
@@ -626,7 +647,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'), 'isAccepted');
       assert.isTrue(updated.get('isAutoResolved'), 'isAutoResolved');
@@ -668,7 +690,8 @@ describe('Comment Domain Rules Tests', () => {
       ];
 
       await resolveComment(comment, scores, rules);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'), 'isAccepted');
       assert.isFalse(updated.get('isAutoResolved'), 'isAutoResolved');
@@ -686,7 +709,8 @@ describe('Comment Domain Rules Tests', () => {
       const comment = await createComment({ articleId: article.id });
 
       await processRulesForComment(comment);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'));
       assert.isFalse(updated.get('isAutoResolved'));
@@ -712,7 +736,8 @@ describe('Comment Domain Rules Tests', () => {
       ]);
 
       await processRulesForComment(comment);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isNull(updated.get('isAccepted'));
       assert.isFalse(updated.get('isAutoResolved'));
@@ -763,7 +788,8 @@ describe('Comment Domain Rules Tests', () => {
       ]);
 
       await processRulesForComment(comment);
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
 
       assert.isTrue(updated.get('isAccepted'));
       assert.isTrue(updated.get('isAutoResolved'));
@@ -814,7 +840,8 @@ describe('Comment Domain Rules Tests', () => {
 
       await processRulesForComment(comment);
 
-      const updated = (await Comment.findById(comment.id))!;
+      const updated = await Comment.findById(comment.id);
+      assert.isNotNull(updated);
       assert.isNull(updated.get('isAccepted'));
     });
   });

--- a/packages/backend-core/src/test/test_helper.ts
+++ b/packages/backend-core/src/test/test_helper.ts
@@ -34,9 +34,4 @@ function cleanDatabase(done: any) {
       .then(() => done(), (e) => done(e));
 }
 
-beforeEach('Clean database before each test run', cleanDatabase);
-after((done) => {
-  setTimeout(() => {
-    cleanDatabase(done);
-  }, 1000);
-});
+before('Clean database before', cleanDatabase);

--- a/packages/backend-queue/src/tasks/process_tagging.ts
+++ b/packages/backend-queue/src/tasks/process_tagging.ts
@@ -93,7 +93,7 @@ export const processTagAdditionTask: IQueueHandler<IProcessTagAdditionData> = ha
     }
 
     await denormalizeCountsForComment(comment);
-    await denormalizeCommentCountsForArticle(comment.get('article'));
+    await denormalizeCommentCountsForArticle(await comment.getArticle());
   } catch (err) { // Catching just for logging purposes
     logger.error('Catch Tag Addition', err);
     throw err;
@@ -138,7 +138,7 @@ export const processTagRevocationTask = handler<IProcessTagRevocationData>(async
     });
 
     await denormalizeCountsForComment(comment);
-    await denormalizeCommentCountsForArticle(comment.get('article'));
+    await denormalizeCommentCountsForArticle(await comment.getArticle());
   } catch (err) { // Catching just for logging purposes
     logger.error('Catch Tag Revocation', err);
     throw err;

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -116,7 +116,7 @@ const config = convict({
     run_immediately: {
       doc: 'If true, we skip redis and run all tasks synchronously',
       format: Boolean,
-      default: false,
+      default: true,
       env: 'WORKER_RUN_IMMEDIATELY',
     },
     run_scheduled_tasks: {
@@ -149,7 +149,7 @@ const config = convict({
   redirect_oauth_to: {
     doc: 'Where to redirect successful OAUTH',
     format: String,
-    default: 'frontend_url',
+    default: 'referrer',
     env: 'REDIRECT_OAUTH_TO'
   },
 

--- a/packages/config/sequelize.js
+++ b/packages/config/sequelize.js
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const path = require('path');
 const config = require('./index').config;
 
 /**
@@ -29,6 +28,7 @@ let mysqlConfig = {
   database: config.get('database_name'),
   username: config.get('database_user'),
   password: config.get('database_password'),
+  // TODO: Convince CLI to use correct character set
 };
 
 if (config.get('database_socket') !== 'nevermind') {

--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:webpack": "npm run compile:lib && NODE_ENV=production webpack --bail --progress --profile --colors --config tooling/webpack.config.production.js",
     "build:copy": "cp -R public/* build/",
-    "build": "npm run compile && npm run compile:lib && npm run build:webpack && npm run storybook:build && npm run build:copy",
+    "build": "npm run compile:web && npm run build:webpack && npm run storybook:build && npm run build:copy",
     "lint": "find src -name *.ts -o -name *.tsx | xargs ../../node_modules/.bin/tslint -c ../../tslint.json",
     "watch": "npm run compile && npm run compile:watch | PORT=8000 webpack-dev-server --config tooling/webpack.config.js --progress --colors --host 0.0.0.0",
     "lint:fix": "find src -name *.ts -o -name *.tsx | xargs ../../node_modules/.bin/tslint -c ../../tslint.json --fix",

--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -9,7 +9,7 @@
     "build:copy": "cp -R public/* build/",
     "build": "npm run compile:web && npm run build:webpack && npm run storybook:build && npm run build:copy",
     "lint": "find src -name *.ts -o -name *.tsx | xargs ../../node_modules/.bin/tslint -c ../../tslint.json",
-    "watch": "npm run compile && npm run compile:watch | PORT=8000 webpack-dev-server --config tooling/webpack.config.js --progress --colors --host 0.0.0.0",
+    "watch": "npm run compile && npm run compile:watch | PORT=8000 API_URL=http://localhost:8080 webpack-dev-server --config tooling/webpack.config.js --progress --colors --host 0.0.0.0",
     "lint:fix": "find src -name *.ts -o -name *.tsx | xargs ../../node_modules/.bin/tslint -c ../../tslint.json --fix",
     "test": "npm run spec && npm run storybook:test",
     "spec": "jest dist-commonjs/**",

--- a/packages/frontend-web/tsconfig.json
+++ b/packages/frontend-web/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "strictPropertyInitialization": false,
     "noImplicitAny": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,

--- a/packages/youtube/commands/youtube/objectmap.ts
+++ b/packages/youtube/commands/youtube/objectmap.ts
@@ -198,12 +198,12 @@ export async function foreachPendingDecision(callback: (decision: IDecisionInsta
   });
 
   for (const d of decisions) {
-    callback(d, await d.getComment());
+    callback(d, (await d.getComment())!);
   }
 }
 
 export async function markDecisionExecuted(decision: IDecisionInstance) {
   decision.set('sentBackToPublisher', sequelize.fn('now')).save();
-  const comment = await decision.getComment();
+  const comment = (await decision.getComment())!;
   comment.set('sentBackToPublisher', sequelize.fn('now')).save();
 }


### PR DESCRIPTION
Minor maintenance fixes.  
- Fixes to speed up the unit tests.  These can be run in less than a minute.  (Down from multiple tens of minutes.)  Previously, test was creating and tearing down the database for every test.  Insetead just create and tear down at the start and end of the test run.  For each individual test, just delete the data we are interested in.

- Sequelize update: Switch to model-specific getters when fetching associated entities.  You should only use the generic getter when you've preloaded the obect during the search/fetch.

- Also upgrade typescript to 2.8 which now appears just to work.  (I assume this is a byproduct of the sequelize fixes.)

- Also some minor deployment improvements.  WORKER_RUN_IMMEDIATELY is now the default.

- Introduce some tools to help manage schema migrations.  It generates a diff of the schema generated via migrations and via sequelize sync command.   It also goes some way to reducing the current differences.