### PR TITLE
Configure OAuth settings via the UI

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -21,6 +21,8 @@ http://<domain name from step 0>/api/auth/callback/google
 http://<domain name from step 0>/api/youtube/callback
 ```
 
+You'll be asked to enter this information when you first log into OS Moderator.
+
 Step 2:
 -------
 
@@ -57,8 +59,6 @@ Step 5:
 Set the following environment variables
 ```
 export MODERATOR_URL=http://<domain name from step 0>
-export GOOGLE_CLIENT_ID=<Client ID from step 1>
-export GOOGLE_CLIENT_SECRET=<Client secret from step 1>
 export GOOGLE_CLOUD_API_KEY=<API key from step 4>
 export DATABASE_PASSWORD=password
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,6 @@ must be set in the environment before anything will work.
 * `DATABASE_NAME`: The MySQL database name, e.g., 'os_moderator'.
 * `DATABASE_USER`: The MySQL database user, e.g., 'os_moderator'.
 * `DATABASE_PASSWORD`: The MySQL database password.
-* `GOOGLE_CLIENT_ID`: Google OAuth API client id.
-* `GOOGLE_CLIENT_SECRET`:  Google OAuth API secret.
-
-To get values for the `GOOGLE_CLIENT_*` parameters, create an OAuth2.0 Client ID
-entry for your app in the [Google API console](https://console.developers.google.com/apis/credentials).
-Set the Authorised redirect URI to `http://localhost:8080/auth/callback/google`.
-(Replace localhost with the address of your server if you are not running
-locally.)
 
 In a production setting, you'll also have to set the following:
 

--- a/deployments/gcloud/README.md
+++ b/deployments/gcloud/README.md
@@ -108,17 +108,6 @@ DATABASE_SOCKET=/cloudsql/$SQL_CONNECTION bin/osmod users:create --group general
 mysql --socket=/cloudsql/$SQL_CONNECTION --user=root --password=$DATABASE_PASSWORD
 ```
 
-### Configure OAuth authentication
-
-To configure the Google OAuth authenticator for your app, visit
-[Google API console](https://console.developers.google.com/apis/credentials),
-and OAuth2.0 Client ID entry.  (Make sure the correct project is selected.)
-Set the Authorised redirect URI to `http://<domain name or IP address>:8080/auth/callback/google`.
-
-(Unfortunately, there does not seem to be a way to configure this via the
-commandline.  If Google add the necessary features, we'll update this document
-accordingly.)
-
 ## Do the deployment
 
 ### Generate a docker file and upload it to a registry
@@ -143,8 +132,6 @@ docker run --publish 8080:8080 --publish 8000:8000 \
    --env DATABASE_USER=$DATABASE_USER \
    --env DATABASE_PASSWORD=$DATABASE_PASSWORD \
    --env GOOGLE_SCORE_AUTH=$GOOGLE_SCORE_AUTH \
-   --env GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
-   --env GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET \
    --mount type=bind,source=/cloudsql,destination=/cloudsql/
    $MODERATOR_IMAGE_ID
 ```
@@ -166,8 +153,6 @@ export BILLING=<as set above>
 export DATABASE_NAME=os_moderator
 export DATABASE_USER=os_moderator
 export DATABASE_PASSWORD=password
-export GOOGLE_CLIENT_ID=<as retrieved when setting up OAuth>
-export GOOGLE_CLIENT_SECRET=<as retrieved when setting up OAuth>
 export GOOGLE_SCORE_AUTH=<get this from Jigsaw/Perspective team>
 export FRONTEND_URL=http://<hostname or IP address>/
 export API_URL=http://<hostname or IP address>:8080/
@@ -217,7 +202,6 @@ kubectl describe deployments conversationai-moderator
  - Integrate statically allocated IP address
    e.g., https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip
  - Separate frontend and api into separate containers?
- - Work out how to automate configuration of GOOGLE_CLIENT_*
  - Enable SSH in the load balancer
 
 

--- a/deployments/gcloud/deploy.sh
+++ b/deployments/gcloud/deploy.sh
@@ -12,8 +12,6 @@ kubectl create secret generic moderator-configuration \
   --from-literal=DATABASE_USER=$DATABASE_USER \
   --from-literal=DATABASE_PASSWORD=$DATABASE_PASSWORD \
   --from-literal=GOOGLE_SCORE_AUTH=$GOOGLE_SCORE_AUTH \
-  --from-literal=GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
-  --from-literal=GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET \
   --from-literal=SQL_CONNECTION=$SQL_CONNECTION
 
 envsubst < kubernetes-deployment.yaml | kubectl apply -f -

--- a/deployments/gcloud/kubernetes-deployment.yaml
+++ b/deployments/gcloud/kubernetes-deployment.yaml
@@ -40,16 +40,6 @@ spec:
                 secretKeyRef:
                   name: moderator-configuration
                   key: GOOGLE_SCORE_AUTH
-            - name: GOOGLE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: moderator-configuration
-                  key: GOOGLE_CLIENT_ID
-            - name: GOOGLE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: moderator-configuration
-                  key: GOOGLE_CLIENT_SECRET
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.11
           command: ["/cloud_sql_proxy"]

--- a/deployments/local/docker-compose.yml
+++ b/deployments/local/docker-compose.yml
@@ -28,8 +28,6 @@ services:
       DATABASE_USER: 'os_moderator'
       DATABASE_PASSWORD: "${DATABASE_PASSWORD}"
       REDIS_URL: 'redis://redis:6379'
-      GOOGLE_CLIENT_ID: "${GOOGLE_CLIENT_ID}"
-      GOOGLE_CLIENT_SECRET: "${GOOGLE_CLIENT_SECRET}"
       HTTPS_LINKS_ONLY: 'false'
       APP_NAME: 'Moderator'
       GOOGLE_CLOUD_API_KEY: "${GOOGLE_CLOUD_API_KEY}"

--- a/deployments/standalone/Dockerfile
+++ b/deployments/standalone/Dockerfile
@@ -3,8 +3,6 @@ FROM ubuntu:bionic
 RUN apt update && apt --assume-yes dist-upgrade && apt --assume-yes install mysql-server nodejs npm redis supervisor && npm install -g npm
 
 ENV DATABASE_PASSWORD=$DATABASE_PASSWORD
-ENV GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
-ENV GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
 
 WORKDIR /app
 

--- a/packages/backend-api/src/api/router.ts
+++ b/packages/backend-api/src/api/router.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as express from 'express';
 
+import { createAuthConfigRouter } from '../auth/router';
 import { createAssistantRouter } from './assistant';
 import { createPublisherRouter } from './publisher';
 import { createRESTRouter } from './rest';
@@ -34,6 +35,8 @@ export function createApiRouter(authenticator: any) {
       (router as any)[method]('*', authenticator);
     });
   }
+
+  router.use('/', createAuthConfigRouter());
 
   // The REST API provides standard CRUD operations on our database models using
   // the JSONAPI scheme format.

--- a/packages/backend-api/src/api/services/updateNotifications.ts
+++ b/packages/backend-api/src/api/services/updateNotifications.ts
@@ -424,7 +424,6 @@ export function createUpdateNotificationService(): express.Router {
   return router;
 }
 
-// Used in testing
 export function destroyUpdateNotificationService() {
   lastAllArticlesMessage = null;
   for (const si of socketItems.values()) {

--- a/packages/backend-api/src/auth/config.ts
+++ b/packages/backend-api/src/auth/config.ts
@@ -19,7 +19,7 @@ import { CONFIGURATION_GOOGLE_OAUTH, getConfigItem, setConfigItem } from '../mod
 export interface IGoogleOAuthConfiguration {
   id: string;
   secret: string;
-  knownGood: boolean;
+  knownBad?: boolean;
 }
 
 export async function getOAuthConfiguration() {

--- a/packages/backend-api/src/auth/config.ts
+++ b/packages/backend-api/src/auth/config.ts
@@ -19,7 +19,6 @@ import { CONFIGURATION_GOOGLE_OAUTH, getConfigItem, setConfigItem } from '../mod
 export interface IGoogleOAuthConfiguration {
   id: string;
   secret: string;
-  knownBad?: boolean;
 }
 
 export async function getOAuthConfiguration() {
@@ -28,4 +27,14 @@ export async function getOAuthConfiguration() {
 
 export async function setOAuthConfiguration(oauthConfig: IGoogleOAuthConfiguration) {
   return await setConfigItem(CONFIGURATION_GOOGLE_OAUTH, oauthConfig);
+}
+
+let oauthGood = false;
+
+export async function setOAuthGood(isGood: boolean) {
+  oauthGood = isGood;
+}
+
+export async function isOAuthGood() {
+  return oauthGood;
 }

--- a/packages/backend-api/src/auth/config.ts
+++ b/packages/backend-api/src/auth/config.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { CONFIGURATION_GOOGLE_OAUTH, getConfigItem, setConfigItem } from '../models';
+
+export interface IGoogleOAuthConfiguration {
+  id: string;
+  secret: string;
+  knownGood: boolean;
+}
+
+export async function getOAuthConfiguration() {
+  return await getConfigItem(CONFIGURATION_GOOGLE_OAUTH) as IGoogleOAuthConfiguration | null;
+}
+
+export async function setOAuthConfiguration(oauthConfig: IGoogleOAuthConfiguration) {
+  return await setConfigItem(CONFIGURATION_GOOGLE_OAUTH, oauthConfig);
+}

--- a/packages/backend-api/src/auth/providers/google.ts
+++ b/packages/backend-api/src/auth/providers/google.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { config } from '@conversationai/moderator-config';
 
 import { IUserInstance, User } from '../../models';
+import { IGoogleOAuthConfiguration } from '../config';
 import { ensureFirstUser, findOrCreateUserSocialAuth, isFirstUserInitialised } from '../users';
 
 const Strategy = require('passport-google-oauth20').Strategy;
@@ -106,15 +107,18 @@ export async function verifyGoogleToken(accessToken: string, refreshToken: strin
   return user;
 }
 
-export async function getGoogleStrategy() {
+export function getGoogleStrategy(
+  oauthConfig: IGoogleOAuthConfiguration,
+) {
   return new Strategy(
     {
-      clientID: config.get('google_client_id'),
-      clientSecret: config.get('google_client_secret'),
+      clientID: oauthConfig.id,
+      clientSecret: oauthConfig.secret,
       callbackURL: `${config.get('api_url')}/auth/callback/google`,
       userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
     },
-    async (accessToken: string, refreshToken: string, profile: IGoogleProfile, callback: (err: any, user?: IUserInstance | false, info?: any) => any) => {
+    async (accessToken: string, refreshToken: string, profile: IGoogleProfile,
+           callback: (err: any, user?: IUserInstance | false, info?: any) => any) => {
       try {
         const user = await verifyGoogleToken(accessToken, refreshToken, profile);
 

--- a/packages/backend-api/src/auth/providers/google.ts
+++ b/packages/backend-api/src/auth/providers/google.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { config } from '@conversationai/moderator-config';
 
 import { IUserInstance, User } from '../../models';
-import { IGoogleOAuthConfiguration } from '../config';
+import { IGoogleOAuthConfiguration, setOAuthGood } from '../config';
 import { ensureFirstUser, findOrCreateUserSocialAuth, isFirstUserInitialised } from '../users';
 
 const Strategy = require('passport-google-oauth20').Strategy;
@@ -86,6 +86,8 @@ export async function verifyGoogleToken(accessToken: string, refreshToken: strin
   if (!await isFirstUserInitialised()) {
     await ensureFirstUser(userData);
   }
+
+  await setOAuthGood(true);
 
   const user = await User.findOne({
     where: {

--- a/packages/backend-api/src/auth/providers/google.ts
+++ b/packages/backend-api/src/auth/providers/google.ts
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO: Passport seems to be a dead project.  Keep an eye on what is happening
-//     And consider replacing it with passport-next or something else.
-
 import { config } from '@conversationai/moderator-config';
 
 import { IUserInstance, User } from '../../models';

--- a/packages/backend-api/src/auth/router.ts
+++ b/packages/backend-api/src/auth/router.ts
@@ -21,6 +21,7 @@ import * as qs from 'qs';
 import { config } from '@conversationai/moderator-config';
 
 import { IUserInstance } from '../models';
+import { restartService } from '../server-management';
 import { createToken } from './tokens';
 import { isFirstUserInitialised } from './users';
 import { generateServerCSRF, getClientCSRF } from './utils';
@@ -65,6 +66,25 @@ export function createHealthcheckRouter(): express.Router {
         return;
       }
       res.status(218).send('init_first_user');
+    },
+  );
+
+  return router;
+}
+
+export function createAuthConfigRouter(): express.Router {
+  const router = express.Router({
+    caseSensitive: true,
+    mergeParams: true,
+  });
+
+  router.get(
+    '/auth/config',
+    async (_req, res, next) => {
+      restartService();
+      res.send('ok');
+      next();
+      return;
     },
   );
 

--- a/packages/backend-api/src/auth/router.ts
+++ b/packages/backend-api/src/auth/router.ts
@@ -22,6 +22,7 @@ import { config } from '@conversationai/moderator-config';
 
 import { IUserInstance } from '../models';
 import { restartService } from '../server-management';
+import { getOAuthConfiguration, IGoogleOAuthConfiguration, setOAuthConfiguration } from './config';
 import { createToken } from './tokens';
 import { isFirstUserInitialised } from './users';
 import { generateServerCSRF, getClientCSRF } from './utils';
@@ -81,10 +82,24 @@ export function createAuthConfigRouter(): express.Router {
   router.get(
     '/auth/config',
     async (_req, res, next) => {
+      const data = await getOAuthConfiguration();
+      const id = (data && data.id) ? data.id : '';
+      const secret = (data && data.secret) ? 'X'.repeat(data.secret.length - 5) + data.secret.substr(-5) : '';
+      res.json({ google_oauth_config: {
+        id: id,
+        secret: secret,
+      }});
+      next();
+    },
+  );
+
+  router.post(
+    '/auth/config',
+    async (req, res, next) => {
+      await setOAuthConfiguration(req.body.data as IGoogleOAuthConfiguration);
       restartService();
       res.send('ok');
       next();
-      return;
     },
   );
 

--- a/packages/backend-api/src/auth/youtube.ts
+++ b/packages/backend-api/src/auth/youtube.ts
@@ -19,10 +19,14 @@ import { google } from 'googleapis';
 
 import { config } from '@conversationai/moderator-config';
 
+import { IGoogleOAuthConfiguration } from './config';
 import { saveYouTubeUserToken } from './users';
 import { generateServerCSRF, getClientCSRF } from './utils';
 
-export function createYouTubeRouter(authenticator: any): express.Router {
+export function createYouTubeRouter(
+  oauthConfig: IGoogleOAuthConfiguration,
+  authenticator: any,
+): express.Router {
   const router = express.Router({
     caseSensitive: true,
     mergeParams: true,
@@ -43,8 +47,8 @@ export function createYouTubeRouter(authenticator: any): express.Router {
       }
 
       const oauth2Client = new google.auth.OAuth2(
-        config.get('google_client_id'),
-        config.get('google_client_secret'),
+        oauthConfig.id,
+        oauthConfig.secret,
         `${config.get('api_url')}/youtube/callback`);
       const authUrl = oauth2Client.generateAuthUrl({
         access_type: 'offline',
@@ -74,8 +78,8 @@ export function createYouTubeRouter(authenticator: any): express.Router {
       }
 
       const oauth2Client = new google.auth.OAuth2(
-        config.get('google_client_id'),
-        config.get('google_client_secret'),
+        oauthConfig.id,
+        oauthConfig.secret,
         `${config.get('api_url')}/youtube/callback`, );
       const tokenRsp = await oauth2Client.getToken(req.query.code);
       const token = tokenRsp.tokens;

--- a/packages/backend-api/src/index.ts
+++ b/packages/backend-api/src/index.ts
@@ -25,7 +25,6 @@ import { config } from '@conversationai/moderator-config';
 import { createApiRouter } from './api/router';
 import { getGoogleStrategy, getJwtStrategy } from './auth/providers';
 import {
-  createAuthConfigRouter,
   createAuthRouter,
   createHealthcheckRouter,
 } from './auth/router';
@@ -68,7 +67,6 @@ export async function mountAPI(testMode?: boolean): Promise<express.Express> {
   });
 
   app.use('/', createHealthcheckRouter());
-  app.use('/', createAuthConfigRouter());
   app.use('/', createAuthRouter());
   app.use('/', createYouTubeRouter(jwtAuthenticator));
   app.use('/', createApiRouter(jwtAuthenticator));

--- a/packages/backend-api/src/index.ts
+++ b/packages/backend-api/src/index.ts
@@ -23,7 +23,7 @@ import * as passport from 'passport';
 import { config } from '@conversationai/moderator-config';
 
 import { createApiRouter } from './api/router';
-import { getOAuthConfiguration } from './auth/config';
+import { getOAuthConfiguration, isOAuthGood } from './auth/config';
 import { getGoogleStrategy, getJwtStrategy } from './auth/providers';
 import {
   createAuthConfigRouter,
@@ -45,7 +45,7 @@ export async function mountAPI(testMode?: boolean): Promise<express.Express> {
   // (Authenticator doesn't have a well-defined type...)
   let jwtAuthenticator: any;
   const oauthConfig = await getOAuthConfiguration();
-  const oauthOk = oauthConfig != null && !oauthConfig.knownBad;
+  const oauthOk = oauthConfig != null && await isOAuthGood();
 
   if (!testMode) {
     passport.use(await getJwtStrategy());

--- a/packages/backend-api/src/index.ts
+++ b/packages/backend-api/src/index.ts
@@ -49,7 +49,9 @@ export async function mountAPI(testMode?: boolean): Promise<express.Express> {
 
   if (!testMode) {
     passport.use(await getJwtStrategy());
-    passport.use(await getGoogleStrategy());
+    if (oauthConfig) {
+      passport.use(getGoogleStrategy(oauthConfig));
+    }
     app.use(passport.initialize());
     jwtAuthenticator = passport.authenticate('jwt', { session: false });
   }
@@ -79,7 +81,9 @@ export async function mountAPI(testMode?: boolean): Promise<express.Express> {
   }
 
   app.use('/', createAuthRouter());
-  app.use('/', createYouTubeRouter(jwtAuthenticator));
+  if (oauthOk) {
+    app.use('/', createYouTubeRouter(oauthConfig!, jwtAuthenticator));
+  }
   app.use('/', createApiRouter(jwtAuthenticator));
 
   return app;

--- a/packages/backend-api/src/index.ts
+++ b/packages/backend-api/src/index.ts
@@ -16,13 +16,19 @@ limitations under the License.
 
 import * as express from 'express';
 import * as expressWs from 'express-ws';
+// TODO: Passport seems to be a dead project.  Keep an eye on what is happening
+//     And consider replacing it with passport-next or something else.
 import * as passport from 'passport';
 
 import { config } from '@conversationai/moderator-config';
 
 import { createApiRouter } from './api/router';
 import { getGoogleStrategy, getJwtStrategy } from './auth/providers';
-import { createAuthRouter, createHealthcheckRouter } from './auth/router';
+import {
+  createAuthConfigRouter,
+  createAuthRouter,
+  createHealthcheckRouter,
+} from './auth/router';
 import { createYouTubeRouter } from './auth/youtube';
 
 export async function mountAPI(testMode?: boolean): Promise<express.Express> {
@@ -62,6 +68,7 @@ export async function mountAPI(testMode?: boolean): Promise<express.Express> {
   });
 
   app.use('/', createHealthcheckRouter());
+  app.use('/', createAuthConfigRouter());
   app.use('/', createAuthRouter());
   app.use('/', createYouTubeRouter(jwtAuthenticator));
   app.use('/', createApiRouter(jwtAuthenticator));

--- a/packages/backend-api/src/integrations/youtube/authenticate.ts
+++ b/packages/backend-api/src/integrations/youtube/authenticate.ts
@@ -17,8 +17,7 @@ limitations under the License.
 import { OAuth2Client } from 'google-auth-library';
 import { google } from 'googleapis';
 
-import { config } from '@conversationai/moderator-config';
-
+import { getOAuthConfiguration } from '../../auth/config';
 import { logger } from '../../logger';
 import { IUserInstance, User, USER_GROUP_YOUTUBE } from '../../models';
 
@@ -28,7 +27,12 @@ export async function for_one_youtube_user(
   user: IUserInstance,
   callback: (owner: IUserInstance, client: OAuth2Client) => Promise<void>,
 ) {
-  const oauth2Client = new google.auth.OAuth2(config.get('google_client_id'), config.get('google_client_secret'));
+  const oauthConfig = await getOAuthConfiguration();
+  if (!oauthConfig || oauthConfig.knownBad) {
+    return;
+  }
+
+  const oauth2Client = new google.auth.OAuth2(oauthConfig.id, oauthConfig.secret);
   logger.info(`Youtube: Authenticating as: ${user.id}:${user.get('email')} (${user.get('name')})`);
   const extra = JSON.parse(user.get('extra'));
   oauth2Client.setCredentials(extra.token);

--- a/packages/backend-api/src/integrations/youtube/authenticate.ts
+++ b/packages/backend-api/src/integrations/youtube/authenticate.ts
@@ -28,7 +28,7 @@ export async function for_one_youtube_user(
   callback: (owner: IUserInstance, client: OAuth2Client) => Promise<void>,
 ) {
   const oauthConfig = await getOAuthConfiguration();
-  if (!oauthConfig || oauthConfig.knownBad) {
+  if (!oauthConfig) {
     return;
   }
 

--- a/packages/backend-api/src/models/configuration.ts
+++ b/packages/backend-api/src/models/configuration.ts
@@ -28,6 +28,7 @@ import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
 
 export const CONFIGURATION_TOKEN = 'token';
+export const CONFIGURATION_GOOGLE_OAUTH = 'google-oauth';
 
 interface IConfigurationAttributes {
   data: any;

--- a/packages/backend-api/src/server-management.ts
+++ b/packages/backend-api/src/server-management.ts
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as http from 'http';
+import * as https from 'https';
+
+import { destroyUpdateNotificationService } from './api/services/updateNotifications';
+
+let server: https.Server | http.Server;
+let init: () => void;
+
+export function registerServer(iserver: https.Server | http.Server) {
+  server = iserver;
+}
+
+export function registerInit(iinit: () => void) {
+  init = iinit;
+}
+
+export function restartService() {
+  console.log('*** closing server');
+  server.close(() => {
+    init();
+  });
+  destroyUpdateNotificationService();
+}

--- a/packages/backend-api/src/server-management.ts
+++ b/packages/backend-api/src/server-management.ts
@@ -20,6 +20,7 @@ import { destroyUpdateNotificationService } from './api/services/updateNotificat
 
 let server: https.Server | http.Server;
 let init: () => void;
+let closing = false;
 
 export function registerServer(iserver: https.Server | http.Server) {
   server = iserver;
@@ -30,8 +31,13 @@ export function registerInit(iinit: () => void) {
 }
 
 export function restartService() {
+  if (closing) {
+    return;
+  }
+  closing = true;
   console.log('*** closing server');
   server.close(() => {
+    closing = false;
     init();
   });
   destroyUpdateNotificationService();

--- a/packages/backend-api/src/server.ts
+++ b/packages/backend-api/src/server.ts
@@ -45,6 +45,7 @@ import { mountAPI } from '.';
 import { applyCommonPostprocessors, getExpressAppWithPreprocessors } from './api/util/server';
 import { logger } from './logger';
 import { mountQueueDashboard } from './processing';
+import { registerInit, registerServer } from './server-management';
 
 const frontend_url = config.get('frontend_url');
 if (!frontend_url) {
@@ -102,6 +103,9 @@ async function init() {
   console.log(`Binding to ${pUrl.protocol} ${pUrl.hostname} : ${port}`);
   await server.listen({host: '0.0.0.0', port});
   console.log(`Started server in ${STANDALONE ? 'standalone' : 'API only'} mode`);
+
+  registerServer(server);
 }
 
+registerInit(init);
 init();

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -119,20 +119,6 @@ const config = convict({
     }
   },
 
-  google_client_id: {
-    doc: 'The Google OAuth web client id, found at https://console.developers.google.com',
-    format: String,
-    default: undefined,
-    env: 'GOOGLE_CLIENT_ID'
-  },
-
-  google_client_secret: {
-    doc: 'The Google OAuth web client secret, found at https://console.developers.google.com',
-    format: String,
-    default: undefined,
-    env: 'GOOGLE_CLIENT_SECRET'
-  },
-
   require_reason_to_reject: {
     doc: 'Flag to require moderator to select a reason (tag) to reject a comment',
     format: Boolean,

--- a/packages/frontend-web/src/app/components/SplashRoot.tsx
+++ b/packages/frontend-web/src/app/components/SplashRoot.tsx
@@ -88,14 +88,11 @@ export function Bubbles() {
   );
 }
 
-export function SplashRoot(props: React.PropsWithChildren<{}>) {
+export function SplashFrame(props: React.PropsWithChildren<{}>) {
   return (
     <div>
       <div key="header" className="landing_headerTag">
         Moderator
-      </div>
-      <div key="root" className="landing_centerOnPage">
-        <Bubbles/>
       </div>
       <div key="footer" className="landing_footerTag">
         <a
@@ -108,5 +105,16 @@ export function SplashRoot(props: React.PropsWithChildren<{}>) {
       </div>
       {props.children}
     </div>
+  );
+}
+
+export function SplashRoot(props: React.PropsWithChildren<{}>) {
+  return (
+    <SplashFrame>
+      <div key="root" className="landing_centerOnPage">
+        <Bubbles/>
+      </div>
+      {props.children}
+    </SplashFrame>
   );
 }

--- a/packages/frontend-web/src/app/components/SplashRoot.tsx
+++ b/packages/frontend-web/src/app/components/SplashRoot.tsx
@@ -50,6 +50,14 @@ export const SPLASH_STYLES = stylesheet({
     },
   },
 
+  inlineLink: {
+    color: 'white',
+    textDecoration: 'underline',
+    ':hover': {
+      textDecoration: 'underline',
+    },
+  },
+
   header2Tag: {
     position: 'absolute',
     top: '2vh',

--- a/packages/frontend-web/src/app/main.tsx
+++ b/packages/frontend-web/src/app/main.tsx
@@ -40,7 +40,7 @@ import {
 import { ErrorRoot, SPLASH_STYLES, SplashRoot, ThemeRoot } from './components';
 import { APP_NAME } from './config';
 import { AppRoot, reducer as scenesReducer } from './scenes';
-import { Login } from './scenes/Login';
+import { ConfigureOAuth, Login } from './scenes/Login';
 import { reducer as globalReducer} from './stores';
 import { COMMON_STYLES } from './stylesx';
 import { css } from './utilx';
@@ -106,8 +106,13 @@ function _Root(props: React.PropsWithChildren<RouteComponentProps<{}>>) {
       return message('Connecting');
     case 's_unavailable':
       return <ErrorRoot errorMessage="Server unavailable" retry={retry}/>;
+    case 's_init_oauth':
+      return <ConfigureOAuth restart={retry}/>;
     case 's_init_first_user':
-      return <Login firstUser/>;
+      function backToOAuth() {
+        setState('s_init_oauth');
+      }
+      return <Login firstUser backToOAuth={backToOAuth}/>;
   }
 
   switch (authState) {
@@ -131,7 +136,7 @@ ReactDOM.render(
   <Provider store={store}>
     <ThemeRoot>
       <BrowserRouter>
-        <Root/>;
+        <Root/>
       </BrowserRouter>
     </ThemeRoot>
   </Provider>,

--- a/packages/frontend-web/src/app/main.tsx
+++ b/packages/frontend-web/src/app/main.tsx
@@ -113,6 +113,8 @@ function _Root(props: React.PropsWithChildren<RouteComponentProps<{}>>) {
         setState('s_init_oauth');
       }
       return <Login firstUser backToOAuth={backToOAuth}/>;
+    case 's_init_check_oauth':
+      return <Login backToOAuth={backToOAuth}/>;
   }
 
   switch (authState) {

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -724,6 +724,16 @@ export async function syncCommentSource(categoryId: ModelId): Promise<void> {
   await axios.get(serviceURL('comment_sources', `/sync/${categoryId}`));
 }
 
-export async function getOAuthConfig(): Promise<void> {
-  await axios.get(`${API_URL}${AUTH_URL}/config`);
+export interface IApiConfiguration {
+  id: string;
+  secret: string;
+}
+
+export async function getOAuthConfig(): Promise<IApiConfiguration> {
+  const response: any = await axios.get(`${API_URL}${AUTH_URL}/config`);
+  return response.data.google_oauth_config as IApiConfiguration;
+}
+
+export async function updateOAuthConfig(config: IApiConfiguration): Promise<void> {
+  await axios.post(`${API_URL}${AUTH_URL}/config`, {data: config});
 }

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -583,6 +583,8 @@ export async function checkServerStatus(): Promise<ServerStates> {
         return 's_init_oauth';
       case 'init_first_user':
         return 's_init_first_user';
+      case 'init_check_oauth':
+        return 's_init_check_oauth';
     }
   }
   return 's_gtg';

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -126,6 +126,11 @@ function serializeParams(originalParams?: Partial<IParams> | null): string {
 }
 
 /**
+ * Base AUTH API Path
+ */
+const AUTH_URL = `/auth`;
+
+/**
  * Base REST API Path
  */
 const REST_URL = `/rest`;
@@ -570,7 +575,7 @@ export function getCommentFlags(commentId: string) {
 
 export async function checkServerStatus(): Promise<ServerStates> {
   const response = await axios.get(
-    `${API_URL}/auth/healthcheck`,
+    `${API_URL}${AUTH_URL}/healthcheck`,
   );
   if (response.status === 218) {
     if (response.data === 'init_first_user') {
@@ -585,7 +590,7 @@ export async function checkServerStatus(): Promise<ServerStates> {
  */
 export async function checkAuthorization(): Promise<void> {
   await axios.get(
-    `${API_URL}/auth/test`,
+    `${API_URL}${AUTH_URL}/test`,
   );
 }
 
@@ -717,4 +722,8 @@ export async function activateCommentSource(categoryId: ModelId, activate: boole
 
 export async function syncCommentSource(categoryId: ModelId): Promise<void> {
   await axios.get(serviceURL('comment_sources', `/sync/${categoryId}`));
+}
+
+export async function getOAuthConfig(): Promise<void> {
+  await axios.get(`${API_URL}${AUTH_URL}/config`);
 }

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -578,8 +578,11 @@ export async function checkServerStatus(): Promise<ServerStates> {
     `${API_URL}${AUTH_URL}/healthcheck`,
   );
   if (response.status === 218) {
-    if (response.data === 'init_first_user') {
-      return 's_init_first_user';
+    switch (response.data) {
+      case 'init_oauth':
+        return 's_init_oauth';
+      case 'init_first_user':
+        return 's_init_first_user';
     }
   }
   return 's_gtg';

--- a/packages/frontend-web/src/app/scenes/Login/ConfigureOAuth.tsx
+++ b/packages/frontend-web/src/app/scenes/Login/ConfigureOAuth.tsx
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import React, {useState} from 'react';
+
+import { SPLASH_STYLES, SplashFrame, SplashRoot } from '../../components';
+import { getOAuthConfig, IApiConfiguration, updateOAuthConfig } from '../../platform/dataService';
+import { COMMON_STYLES } from '../../stylesx';
+import { css, stylesheet } from '../../utilx';
+import { OAuthConfig } from '../Settings/components/OAuthConfig';
+
+export const STYLES = stylesheet({
+  frame: {
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  content: {
+    backgroundColor: 'white',
+    fontSize: '2vh',
+    margin: '7vh 15vw',
+    padding: '2vh 5vh 3vh 5vh',
+    borderRadius: '4vh',
+    maxWidth: '1000px',
+  },
+});
+
+interface IConfigureOAuthProps {
+  restart(): void;
+}
+
+export function ConfigureOAuth(props: IConfigureOAuthProps) {
+  const [state, setState] = useState({id: '', secret: ''});
+  const [reconnecting, setReconnecting] = useState(false);
+
+  React.useEffect(() => {
+    (async () => {
+      const oauthConfig = await getOAuthConfig();
+      setState(oauthConfig);
+    })();
+  }, []);
+
+  async function onClickDone(config: IApiConfiguration) {
+    await updateOAuthConfig(config);
+    setReconnecting(true);
+    // Stall for long enough for the server to reinitialise.
+    setTimeout(props.restart, 5000);
+  }
+
+  if (reconnecting) {
+    return (
+      <SplashRoot>
+        <div key="message" {...css(SPLASH_STYLES.header2Tag, COMMON_STYLES.fadeIn)}>Reconfiguring Server</div>
+      </SplashRoot>
+    );
+  }
+
+  return (
+    <SplashFrame>
+      <div key="frame" {...css(STYLES.frame, COMMON_STYLES.fadeIn)}>
+        <div key="content" {...css(STYLES.content)}>
+          <OAuthConfig
+            onClickDone={onClickDone}
+            id={state.id}
+            secret={state.secret}
+          />
+        </div>
+      </div>
+    </SplashFrame>
+  );
+}

--- a/packages/frontend-web/src/app/scenes/Login/Login.tsx
+++ b/packages/frontend-web/src/app/scenes/Login/Login.tsx
@@ -28,6 +28,7 @@ import { css } from '../../utilx';
 export interface ILoginProps {
   errorMessage?: string;
   firstUser?: boolean;
+  backToOAuth?(): void;
 }
 
 export function Login(props: ILoginProps) {

--- a/packages/frontend-web/src/app/scenes/Login/Login.tsx
+++ b/packages/frontend-web/src/app/scenes/Login/Login.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Google Inc.
+Copyright 2019 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,11 +19,28 @@ import qs from 'query-string';
 import { generate } from 'randomstring';
 import React from 'react';
 
-import { SPLASH_STYLES, SplashRoot } from '../../components';
+import { Bubbles, SPLASH_STYLES, SplashFrame, SplashRoot } from '../../components';
 import { API_URL } from '../../config';
 import { COMMON_STYLES } from '../../stylesx';
 import { IReturnURL, setCSRF, setReturnURL } from '../../util';
-import { css } from '../../utilx';
+import { css, stylesheet } from '../../utilx';
+
+export const STYLES = stylesheet({
+  frame: {
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  content: {
+    color: 'white',
+    textAlign: 'center',
+    fontSize: '2vh',
+    padding: '2vh 5vh 3vh 5vh',
+  },
+});
 
 export interface ILoginProps {
   errorMessage?: string;
@@ -56,40 +73,62 @@ export function Login(props: ILoginProps) {
     window.location.href = url;
   }
 
-  function contents() {
-    if (errorMessage) {
+  function oauthBack() {
+    if (!props.backToOAuth) {
+      return '';
+    }
+    return (
+      <p key="back" style={{fontSize: '1vh'}}>
+        If you are having problems logging in,
+        check your <a onClick={props.backToOAuth} {...css(SPLASH_STYLES.inlineLink)}>OAuth configuration.</a>
+      </p>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <SplashRoot>
       return (
         <div key="login-errors" {...css(SPLASH_STYLES.errors, COMMON_STYLES.fadeIn)}>
           <p key="message">{errorMessage}</p>
           <p key="action" {...css(SPLASH_STYLES.errorsTryAgain)}>
             <a key="try-again" onClick={redirectToLogin} {...css(SPLASH_STYLES.link)}>Try Again</a>
           </p>
+          {oauthBack()}
         </div>
-      );
-    }
-    if (props.firstUser) {
-      return (
-        <div key="first-user" {...css(SPLASH_STYLES.errors, COMMON_STYLES.fadeIn)}>
-          <p key="message">There are no administrators registered yet.</p>
-          <p key="message2">The first person to log in will become the administrator.<br/>
-          Once the first user has registered, the system will be locked down.<br/>
-          Additional users can be added on the settings pages.</p>
-          <p key="action" {...css(SPLASH_STYLES.errorsTryAgain)}>
-            <a onClick={redirectToLogin} {...css(SPLASH_STYLES.link)}>Create First User</a>
-          </p>
-        </div>
-      );
-    }
+      </SplashRoot>
+    );
+  }
+
+  if (props.firstUser) {
     return (
-      <div key="signin" {...css(SPLASH_STYLES.signIn, COMMON_STYLES.fadeIn)}>
-        <a onClick={redirectToLogin} {...css(SPLASH_STYLES.link)}>Sign In</a>
-      </div>
+      <SplashFrame>
+        <div key="frame" {...css(STYLES.frame, COMMON_STYLES.fadeIn)}>
+          <Bubbles/>
+          <div key="first-user" {...css(STYLES.content)}>
+            <p key="message">There are no administrators registered yet.</p>
+            <p key="message2">The first person to log in will become the administrator.<br/>
+              Once the first user has registered, the system will be locked down.<br/>
+              Additional users can be added on the settings pages.</p>
+            <p key="action" {...css(SPLASH_STYLES.errorsTryAgain)}>
+              <a onClick={redirectToLogin} {...css(SPLASH_STYLES.link)}>Create First User</a>
+            </p>
+            <p key="back">
+              This also tests out the OAuth configuration you have just set.<br/>If you are having
+              problems, you may need to revisit the <a onClick={props.backToOAuth} {...css(SPLASH_STYLES.inlineLink)}>OAuth configuration page</a>
+            </p>
+          </div>
+        </div>
+      </SplashFrame>
     );
   }
 
   return (
     <SplashRoot>
-      {contents()}
+      <div key="signin" {...css(SPLASH_STYLES.signIn, COMMON_STYLES.fadeIn)}>
+        <a onClick={redirectToLogin} {...css(SPLASH_STYLES.link)}>Sign In</a>
+        {oauthBack()}
+      </div>
     </SplashRoot>
   );
 }

--- a/packages/frontend-web/src/app/scenes/Login/index.ts
+++ b/packages/frontend-web/src/app/scenes/Login/index.ts
@@ -14,4 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+export { ConfigureOAuth } from './ConfigureOAuth';
 export { Login } from './Login';

--- a/packages/frontend-web/src/app/scenes/Settings/components/OAuthConfig.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/OAuthConfig.tsx
@@ -31,6 +31,7 @@ import { css } from '../../../utilx';
 
 export interface IOAuthConfigProps extends IApiConfiguration {
   onClickDone(config: IApiConfiguration): any;
+  showLogoutWarning?: boolean;
 }
 
 const useStyles = makeStyles((_theme) => ({
@@ -89,9 +90,11 @@ export function OAuthConfig(props: IOAuthConfigProps) {
           variant="outlined"
         />
       </div>
+      {props.showLogoutWarning &&
       <p>
         <b>WARNING:</b> Changing OAuth configuration will log everyone out.
       </p>
+      }
       <p>
         The server will take a few seconds to reconfigure itself after the OAuth configuration has changed,
         and during this time, it will not be available.  If you have login issues, please try again after a few seconds.
@@ -129,7 +132,7 @@ export function EditOAuthScrim(props: {
       <div {...css(SCRIM_STYLE.popup, {position: 'relative', width: '75vw', maxWidth: '800px'})}>
         <OverflowContainer
           header={<ContainerHeader onClickClose={props.close}>OAuth Config</ContainerHeader>}
-          body={<OAuthConfig onClickDone={props.save} id={id} secret={secret}/>}
+          body={<OAuthConfig onClickDone={props.save} id={id} secret={secret} showLogoutWarning/>}
         />
       </div>
     </Scrim>

--- a/packages/frontend-web/src/app/scenes/Settings/components/OAuthConfig.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/OAuthConfig.tsx
@@ -1,0 +1,137 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useCallback, useState } from 'react';
+
+import {
+  Button,
+  makeStyles,
+  TextField,
+} from '@material-ui/core';
+
+import { ContainerHeader, OverflowContainer } from '../../../components/OverflowContainer';
+import { Scrim } from '../../../components/Scrim';
+import { API_URL } from '../../../config';
+import { IApiConfiguration } from '../../../platform/dataService';
+import { SCRIM_STYLE } from '../../../styles';
+import { css } from '../../../utilx';
+
+export interface IOAuthConfigProps extends IApiConfiguration {
+  onClickDone(config: IApiConfiguration): any;
+}
+
+const useStyles = makeStyles((_theme) => ({
+  textField: {
+    width: '40vw',
+  },
+}));
+
+export function OAuthConfig(props: IOAuthConfigProps) {
+  const [id, setId] = useState(props.id);
+  const [secret, setSecret] = useState(props.secret);
+  const classes = useStyles({});
+
+  const idHandler = useCallback((e) => setId(e.target.value), [setId]);
+  const secretHandler = useCallback((e) => setSecret(e.target.value), [setSecret]);
+  function submitHandler() {
+    props.onClickDone({id, secret});
+  }
+
+  return (
+    <div>
+      <p>Configure your connection to the Google Authentication service.</p>
+      <p>
+        To allocate and view tokens, visit <a
+          href="https://console.developers.google.com/apis/credentials"
+          target="_blank"
+          style={{color: 'inherit', fontWeight: 'bold', textDecoration: 'underline'}}
+        >the Google API console</a>.
+        If you haven't yet got an appropriate <b>OAuth Client ID</b> yet, or want to allocate a new one,
+        you can do so by clicking the <b>Create Credentials</b> button and selecting the <b>OAuth</b> entry.
+      </p>
+      <p>
+        When asked for an application type, choose <b>Web application</b>.
+        Set the <b>Authorised redirect URI</b> to <b>{API_URL}/auth/callback/google</b>.
+        (If you want to connect to YouTube, you'll also need to add a second redirect URI
+        of <b>{API_URL}/youtube/callback</b>.)
+      </p>
+      <p>
+        Once allocated, copy the client id and secret into the fields below.
+      </p>
+      <div style={{textAlign: 'center'}}>
+        <TextField
+          className={classes.textField}
+          label="Client ID"
+          value={id}
+          onChange={idHandler}
+          margin="normal"
+          variant="outlined"
+        />
+        <TextField
+          className={classes.textField}
+          label="Client Secret"
+          value={secret}
+          onChange={secretHandler}
+          margin="normal"
+          variant="outlined"
+        />
+      </div>
+      <p>
+        <b>WARNING:</b> Changing OAuth configuration will log everyone out.
+      </p>
+      <p>
+        The server will take a few seconds to reconfigure itself after the OAuth configuration has changed,
+        and during this time, it will not be available.  If you have login issues, please try again after a few seconds.
+      </p>
+      <div style={{textAlign: 'right', marginTop: '2vh', marginRight: '9vw'}}>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={submitHandler}
+          disabled={!(id.length > 0 && secret.length > 0)}
+        >
+          Save Configuration
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function EditOAuthScrim(props: {
+  visible: boolean,
+  config: IApiConfiguration,
+  save(config: IApiConfiguration): void;
+  close(): void,
+}) {
+  const id = props.config ? props.config.id : '';
+  const secret = props.config ? props.config.secret : '';
+
+  return (
+    <Scrim
+      key="oauthScrim"
+      scrimStyles={SCRIM_STYLE.scrim}
+      isVisible={props.visible}
+      onBackgroundClick={props.close}
+    >
+      <div {...css(SCRIM_STYLE.popup, {position: 'relative', width: '75vw', maxWidth: '800px'})}>
+        <OverflowContainer
+          header={<ContainerHeader onClickClose={props.close}>OAuth Config</ContainerHeader>}
+          body={<OAuthConfig onClickDone={props.save} id={id} secret={secret}/>}
+        />
+      </div>
+    </Scrim>
+  );
+}

--- a/packages/frontend-web/src/app/scenes/Settings/components/OAuthConfig.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/OAuthConfig.tsx
@@ -37,6 +37,7 @@ export interface IOAuthConfigProps extends IApiConfiguration {
 const useStyles = makeStyles((_theme) => ({
   textField: {
     width: '40vw',
+    maxWidth: '600px',
   },
 }));
 
@@ -60,7 +61,7 @@ export function OAuthConfig(props: IOAuthConfigProps) {
           target="_blank"
           style={{color: 'inherit', fontWeight: 'bold', textDecoration: 'underline'}}
         >the Google API console</a>.
-        If you haven't yet got an appropriate <b>OAuth Client ID</b> yet, or want to allocate a new one,
+        If you don't yet have an <b>OAuth Client ID</b>, or want to allocate a new one,
         you can do so by clicking the <b>Create Credentials</b> button and selecting the <b>OAuth</b> entry.
       </p>
       <p>
@@ -104,7 +105,7 @@ export function OAuthConfig(props: IOAuthConfigProps) {
           variant="contained"
           color="primary"
           onClick={submitHandler}
-          disabled={!(id.length > 0 && secret.length > 0)}
+          disabled={!id || !secret}
         >
           Save Configuration
         </Button>

--- a/packages/frontend-web/src/types.ts
+++ b/packages/frontend-web/src/types.ts
@@ -20,6 +20,7 @@ export type ServerStates =
   's_init_oauth' |
   's_init_first_user' |
   's_init_perspective' |
+  's_init_check_oauth' |
   's_gtg';
 export type AuthenticationStates = 'initialising' | 'check_token' | 'unauthenticated' | 'gtg';
 export type WebsocketStates = 'ws_connecting' | 'ws_gtg';


### PR DESCRIPTION
This change allows a user to configure the OAuth access  key and secret during the server initialisation process.  It's rather more convoluted than I would've liked so that we can handle the case where the user enters an invalid OAuth key without completely borking the install.

It shouldn't affect the NYT in any way.