### PR TITLE
backend: sequelize: nail types.

### DIFF
--- a/packages/backend-api/src/api/assistant/index.ts
+++ b/packages/backend-api/src/api/assistant/index.ts
@@ -52,8 +52,8 @@ export function createAssistant(): express.Router {
 
       if (scoreRequest) {
         await enqueueProcessMachineScoreTask(
-          scoreRequest.get('commentId'),
-          scoreRequest.get('userId'),
+          scoreRequest.commentId,
+          scoreRequest.userId,
           scoreData,
           runImmediately);
         res.json(REPLY_SUCCESS);

--- a/packages/backend-api/src/api/publisher/articles.ts
+++ b/packages/backend-api/src/api/publisher/articles.ts
@@ -51,7 +51,7 @@ export async function createArticleIfNonExistant(item: IArticleData): Promise<IA
       sourceId: item.sourceId,
       title: item.title,
       text: item.text,
-      sourceCreatedAt: item.createdAt,
+      sourceCreatedAt: new Date(Date.parse(item.createdAt)),
       url: (item.url) ? item.url : '',
       extra: (item.extra) ? item.extra : null,
       isCommentingEnabled: true,

--- a/packages/backend-api/src/api/publisher/articles.ts
+++ b/packages/backend-api/src/api/publisher/articles.ts
@@ -56,6 +56,7 @@ export async function createArticleIfNonExistant(item: IArticleData): Promise<IA
       extra: (item.extra) ? item.extra : null,
       isCommentingEnabled: true,
       isAutoModerated: true,
+      allCount: 0,
       unprocessedCount: 0,
       unmoderatedCount: 0,
       moderatedCount: 0,
@@ -79,7 +80,7 @@ export async function createArticleIfNonExistant(item: IArticleData): Promise<IA
     for (const assignment of subscribedUsers) {
       await ModeratorAssignment.create({
         articleId: article.id,
-        userId: assignment.get('userId'),
+        userId: assignment.userId,
       });
     }
     updateHappened();
@@ -122,6 +123,7 @@ async function createCategory(categoryLabel: string): Promise<number> {
     defaults: {
       label: categoryLabel,
       isActive: true,
+      allCount: 0,
       unprocessedCount: 0,
       moderatedCount: 0,
       unmoderatedCount: 0,

--- a/packages/backend-api/src/api/publisher/articles.ts
+++ b/packages/backend-api/src/api/publisher/articles.ts
@@ -51,7 +51,7 @@ export async function createArticleIfNonExistant(item: IArticleData): Promise<IA
       sourceId: item.sourceId,
       title: item.title,
       text: item.text,
-      sourceCreatedAt: new Date(Date.parse(item.createdAt)),
+      sourceCreatedAt: new Date(item.createdAt),
       url: (item.url) ? item.url : '',
       extra: (item.extra) ? item.extra : null,
       isCommentingEnabled: true,

--- a/packages/backend-api/src/api/publisher/index.ts
+++ b/packages/backend-api/src/api/publisher/index.ts
@@ -77,7 +77,7 @@ export function createPublisherService(): express.Router {
       const results = await mapArticles(items);
 
       const data = results.reduce((sum, { article }) => {
-        sum[article.get('sourceId')] = article.id.toString();
+        sum[article.sourceId] = article.id.toString();
 
         return sum;
       }, {} as IIDMap);
@@ -129,7 +129,7 @@ export function createPublisherService(): express.Router {
         await sendCommentsToScoringQueue(newComments);
 
         const data = results.reduce((sum, c) => {
-          sum[c.get('sourceId')] = c.id.toString();
+          sum[c.sourceId] = c.id.toString();
 
           return sum;
         }, {} as IIDMap);

--- a/packages/backend-api/src/api/services/assignments.ts
+++ b/packages/backend-api/src/api/services/assignments.ts
@@ -150,7 +150,7 @@ export function createAssignmentsService(): express.Router {
     });
 
     const userIdsToBeRemoved = assignmentsForCategory.reduce((prev: Array<number>, current: IUserCategoryAssignmentInstance): Array<number> => {
-      const assignmentUserId: number = current.get('userId');
+      const assignmentUserId: number = current.userId;
       const isInAssignment = userIds.some((userId) => (userId === assignmentUserId));
       if (isInAssignment) {
         return prev;
@@ -206,7 +206,7 @@ export function createAssignmentsService(): express.Router {
     const toRemove = new Array<number>();
 
     for (const a of assignments) {
-      const id = a.get('userId');
+      const id = a.userId;
       if (userIds.has(id)) {
         userIds.delete(id);
       }

--- a/packages/backend-api/src/api/services/commentSources.ts
+++ b/packages/backend-api/src/api/services/commentSources.ts
@@ -80,7 +80,7 @@ function createAction(actionId: string): express.RequestHandler {
       return;
     }
 
-    const action = ACTIONS.get(actionId)!.get(await owner.get('group'));
+    const action = ACTIONS.get(actionId)!.get(owner.group);
     if (!action) {
       res.status(400).json({error: `Category does not support action ${action}`});
       next();

--- a/packages/backend-api/src/api/services/editComment.ts
+++ b/packages/backend-api/src/api/services/editComment.ts
@@ -56,7 +56,7 @@ export function createEditCommentTextService(): express.Router {
           return;
         }
 
-        const author = JSON.parse(comment.get('author'));
+        const author = JSON.parse(comment.author as string);
         author.name =  authorName ? authorName : author.name;
         author.location = authorLocation ? authorLocation : author.location;
 

--- a/packages/backend-api/src/api/services/simple.ts
+++ b/packages/backend-api/src/api/services/simple.ts
@@ -61,7 +61,7 @@ export function createSimpleRESTService(): express.Router {
         simple.extra = {jwt: token};
       }
       else {
-        simple.extra = JSON.parse(u.get('extra'));
+        simple.extra = JSON.parse(u.extra);
         // Make sure we don't send any access tokens out.
         delete simple.extra.token;
       }
@@ -82,22 +82,22 @@ export function createSimpleRESTService(): express.Router {
       return;
     }
 
-    const group = await user.get('group');
+    const group = await user.group;
 
     function isRealUser(g: string) {
       return g === USER_GROUP_ADMIN || g === USER_GROUP_GENERAL;
     }
 
     if (isRealUser(group) || group === USER_GROUP_SERVICE) {
-      user.set('name', req.body.name);
+      user.name = req.body.name;
     }
     if (isRealUser(group)) {
       if (isRealUser(req.body.group)) {
-        user.set('group', req.body.group);
+        user.group = req.body.group;
       }
-      user.set('email', req.body.email);
+      user.email = req.body.email;
     }
-    user.set('isActive', req.body.isActive);
+    user.isActive = req.body.isActive;
     await user.save();
 
     if (group === USER_GROUP_YOUTUBE && req.body.isActive) {
@@ -118,8 +118,8 @@ export function createSimpleRESTService(): express.Router {
       return;
     }
 
-    article.set('isCommentingEnabled', req.body.isCommentingEnabled);
-    article.set('isAutoModerated', req.body.isAutoModerated);
+    article.isCommentingEnabled = req.body.isCommentingEnabled;
+    article.isAutoModerated = req.body.isAutoModerated;
     await article.save();
 
     res.json(REPLY_SUCCESS);
@@ -135,7 +135,7 @@ export function createSimpleRESTService(): express.Router {
       next();
       return;
     }
-    const text = article.get('text');
+    const text = article.text;
     res.json({text: text});
     next();
   });

--- a/packages/backend-api/src/api/services/textSizes.ts
+++ b/packages/backend-api/src/api/services/textSizes.ts
@@ -71,7 +71,7 @@ export function createTextSizesService(): express.Router {
         }, {});
 
         const sizingData = commentSizes.reduce((sum, commentSize: ICommentSizeInstance) => {
-          sum[commentSize.get('commentId').toString()] = commentSize.get('height');
+          sum[commentSize.commentId.toString()] = commentSize.height;
 
           return sum;
         }, defaultData);

--- a/packages/backend-api/src/api/services/updateNotifications.ts
+++ b/packages/backend-api/src/api/services/updateNotifications.ts
@@ -189,7 +189,7 @@ async function getArticleUpdate(articleId: number) {
   const aData = serialiseObject(article, ARTICLE_FIELDS);
 
   const category = await Category.findById(
-    await article.get('categoryId'),
+    article.categoryId,
     {include: [{ model: User, as: 'assignedModerators', attributes: ['id']}]},
   );
 

--- a/packages/backend-api/src/api/util/permissions.ts
+++ b/packages/backend-api/src/api/util/permissions.ts
@@ -24,7 +24,7 @@ export function onlyAdmin(req: express.Request, res: express.Response, next: exp
   }
 
   // TODO(ldixon): check that user is always defined; and if so update types.
-  if (['admin'].indexOf(req.user!.get('group')) === -1) {
+  if (['admin'].indexOf(req.user!.group) === -1) {
     res.status(403).json({ error: 'Only admin users can access this API.' });
   } else {
     next();
@@ -39,7 +39,7 @@ export function onlyServices(req: express.Request, res: express.Response, next: 
   }
 
   // TODO(ldixon): check that user is always defined; and if so update types.
-  if (['service'].indexOf(req.user!.get('group')) === -1) {
+  if (['service'].indexOf(req.user!.group) === -1) {
     res.status(403).json({ error: 'Only service users can access this API.' });
   } else {
     next();
@@ -54,7 +54,7 @@ export function onlyAdminAndServices(req: express.Request, res: express.Response
   }
 
   // TODO(ldixon): check that user is always defined; and if so update types.
-  if (['service', 'admin'].indexOf(req.user!.get('group')) === -1) {
+  if (['service', 'admin'].indexOf(req.user!.group) === -1) {
     res.status(403).json({ error: 'General users cannot acces this API.' });
   } else {
     next();

--- a/packages/backend-api/src/api/util/queryComments.ts
+++ b/packages/backend-api/src/api/util/queryComments.ts
@@ -32,7 +32,7 @@ export async function filterTopScoresByTaggingSensitivity(maxScores: ITopScores,
   const allTaggingSensitivities = await TaggingSensitivity.findAll();
 
   const globalTaggingSensitivity = allTaggingSensitivities.find((ts) => {
-    return !ts.get('categoryId') && !ts.get('tagId');
+    return !ts.categoryId && !ts.tagId;
   });
 
   // Prefetch the associated article
@@ -54,22 +54,22 @@ export async function filterTopScoresByTaggingSensitivity(maxScores: ITopScores,
     const id = parseInt(commentId, 10);
     const scoreDetails = maxScores[id];
     const comment = comments.find((c) => (c != null && c.id === id)) as ICommentInstance;
-    const tagIdToFilter = tagId || comment.get('maxSummaryScoreTagId');
+    const tagIdToFilter = tagId || comment.maxSummaryScoreTagId;
 
     const categoryTaggingSensitivity = allTaggingSensitivities.find((ts) => {
       // We've prefetched the assoicated article, so we can use 'get' to fetch it.
       // But that requires some munging of the sequelize types.
       const article = (comment.get as (key: string) => IArticleInstance)('article');
-      return article && ts.get('categoryId') === article.get('categoryId') && !ts.get('tagId');
+      return article && ts.categoryId === article.categoryId && !ts.tagId;
     });
 
     const completeTaggingSensitivity = allTaggingSensitivities.find((ts) => {
       const article = (comment.get as (key: string) => IArticleInstance)('article');
-      return article && ts.get('categoryId') === article.get('categoryId') && ts.get('tagId') === tagIdToFilter;
+      return article && ts.categoryId === article.categoryId && ts.tagId === tagIdToFilter;
     });
 
     const tagTaggingSensitivity = allTaggingSensitivities.find((ts) => {
-      return !ts.get('categoryId') && ts.get('tagId') === tagIdToFilter;
+      return !ts.categoryId && ts.tagId === tagIdToFilter;
     });
 
     const matchesSensitivity = completeTaggingSensitivity || categoryTaggingSensitivity || tagTaggingSensitivity || globalTaggingSensitivity;
@@ -77,8 +77,8 @@ export async function filterTopScoresByTaggingSensitivity(maxScores: ITopScores,
     if (
       matchesSensitivity &&
       (
-        scoreDetails.score < matchesSensitivity.get('lowerThreshold') ||
-        scoreDetails.score > matchesSensitivity.get('upperThreshold')
+        scoreDetails.score < matchesSensitivity.lowerThreshold ||
+        scoreDetails.score > matchesSensitivity.upperThreshold
       )
     ) {
       // Remove comment from set.

--- a/packages/backend-api/src/auth/providers/google.ts
+++ b/packages/backend-api/src/auth/providers/google.ts
@@ -98,7 +98,7 @@ export async function verifyGoogleToken(accessToken: string, refreshToken: strin
     throw new AuthError(`User ${userData.email} is not yet registered with Moderator.`);
   }
 
-  if (!user.get('isActive')) {
+  if (!user.isActive) {
     throw new AuthError(`User ${userData.email} has been deactivated.`);
   }
 

--- a/packages/backend-api/src/auth/providers/jwt.ts
+++ b/packages/backend-api/src/auth/providers/jwt.ts
@@ -35,11 +35,11 @@ export async function verifyJWT(jwtPayload: any): Promise<IUserInstance> {
 
   if (user) {
     if (isValidUser(user)) {
-      if (user.get('email')) {
-        if (user.get('email') === jwtPayload.email) {
+      if (user.email) {
+        if (user.email === jwtPayload.email) {
           return user;
         } else {
-          throw new Error(`User email does not match token: ${user.get('email')} === ${jwtPayload.email}`);
+          throw new Error(`User email does not match token: ${user.email} === ${jwtPayload.email}`);
         }
       } else {
         return user;

--- a/packages/backend-api/src/auth/router.ts
+++ b/packages/backend-api/src/auth/router.ts
@@ -35,7 +35,7 @@ function redirectToFrontend(
   res: express.Response,
   success: boolean,
   params: object = {},
-  referrer?: string,
+  referrer?: string | null,
 ): void {
   let redirectHost;
 

--- a/packages/backend-api/src/auth/tokens.ts
+++ b/packages/backend-api/src/auth/tokens.ts
@@ -81,7 +81,7 @@ export function isValidToken(tokenPayload: ITokenPayload): boolean {
  * @return {boolean}
  */
 export async function isExpired(user: IUserInstance, tokenPayload: ITokenPayload): Promise<boolean> {
-  if (user.get('group') === 'service') {
+  if (user.group === 'service') {
     return false;
   }
 

--- a/packages/backend-api/src/auth/users.ts
+++ b/packages/backend-api/src/auth/users.ts
@@ -29,7 +29,7 @@ import { IUserSocialAuthAttributes, IUserSocialAuthInstance } from '../models';
  * @param {object} user User model instance
  */
 export function isValidUser(user: IUserInstance): boolean {
-  return user.get('isActive');
+  return user.isActive;
 }
 
 /**
@@ -82,11 +82,13 @@ export async function ensureFirstUser({name, email}: {name: string, email: strin
 
   if (!created) {
     // We are repurposing an existing user.  So ensure they have the correct properties
-    if (!await user.get('isActive')) {
-      await user.set('isActive', true).save();
+    if (!await user.isActive) {
+      user.isActive = true;
+      await user.save();
     }
-    if (await user.get('group') !== USER_GROUP_ADMIN) {
-      await user.set('group', USER_GROUP_ADMIN).save();
+    if (await user.group !== USER_GROUP_ADMIN) {
+      user.group = USER_GROUP_ADMIN;
+      await user.save();
     }
   }
 
@@ -104,10 +106,11 @@ export async function saveYouTubeUserToken({name, email}: {name: string, email: 
   });
 
   if (!created) {
-    if (!await user.get('isActive')) {
-      await user.set('isActive', true).save();
+    if (!await user.isActive) {
+      user.isActive = true;
     }
   }
 
-  await user.set('extra', {token: token}).save();
+  user.extra = {token: token};
+  await user.save();
 }

--- a/packages/backend-api/src/auth/utils.ts
+++ b/packages/backend-api/src/auth/utils.ts
@@ -42,7 +42,7 @@ export async function generateServerCSRF(req: express.Request, res: express.Resp
 }
 
 export async function getClientCSRF(req: express.Request):
-  Promise<{clientCSRF: string|undefined, referrer: string|undefined, errorMessage: string|undefined}> {
+  Promise<{clientCSRF: string|undefined, referrer: string|null|undefined, errorMessage: string|undefined}> {
   const serverCSRF = req.query.state;
   if (!serverCSRF) {
     return {clientCSRF: undefined, referrer: undefined, errorMessage: 'CSRF missing.'};
@@ -57,9 +57,9 @@ export async function getClientCSRF(req: express.Request):
   }
 
   const maxAge = moment().subtract(5, 'minutes').toDate();
-  const age = csrf.get('createdAt');
-  const clientCSRF = csrf.get('clientCSRF');
-  const referrer = csrf.get('referrer');
+  const age = csrf.createdAt;
+  const clientCSRF = csrf.clientCSRF;
+  const referrer = csrf.referrer;
   await csrf.destroy();
 
   if (age < maxAge) {

--- a/packages/backend-api/src/commands/comments/generate.ts
+++ b/packages/backend-api/src/commands/comments/generate.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 import * as yargs from 'yargs';
 
 import { logger } from '../../logger';
-import { Article, Category, Comment, IAuthorAttributes, updateHappened } from '../../models';
+import { Article, Category, Comment, IAuthorAttributes, RESET_COUNTS, updateHappened } from '../../models';
 import { postProcessComment, sendForScoring } from '../../pipeline';
 
 const PREEXISTING_CATEGORIES = 5;
@@ -199,9 +199,10 @@ export async function handler(argv: any) {
         sourceCreatedAt: new Date(Date.now()),
         isCommentingEnabled: true,
         isAutoModerated: true,
+        ...RESET_COUNTS,
       });
 
-      logger.info(`Generated article ${new_article.id}: ${new_article.get('title')}`);
+      logger.info(`Generated article ${new_article.id}: ${new_article.title}`);
       articles.push(new_article);
       await generate_comments();
     }
@@ -211,9 +212,10 @@ export async function handler(argv: any) {
     for (let i = 0; i < argv.categories; i++) {
       const new_category = await Category.create({
         label: get_words(data, 5),
+        ...RESET_COUNTS,
       });
 
-      logger.info(`Generated category ${new_category.id}: ${new_category.get('label')}`);
+      logger.info(`Generated category ${new_category.id}: ${new_category.label}`);
       categories.push(new_category);
 
       if (argv.articles !== 0) {

--- a/packages/backend-api/src/commands/comments/send_to_scorer.ts
+++ b/packages/backend-api/src/commands/comments/send_to_scorer.ts
@@ -66,7 +66,7 @@ export async function handler(argv: any) {
       return;
     }
 
-    if (user.get('group') !== USER_GROUP_MODERATOR) {
+    if (user.group !== USER_GROUP_MODERATOR) {
       logger.error(`User is not a moderator`);
       return;
     }

--- a/packages/backend-api/src/commands/users/get_token.ts
+++ b/packages/backend-api/src/commands/users/get_token.ts
@@ -61,8 +61,8 @@ export async function handler(argv: any) {
       process.exit(1);
       return;
     }
-    const token = await createToken(user.id, user.get('email'));
-    logger.info(`JWT token for "${user.get('name')}" (id: ${user.id}):\n\t${token}`);
+    const token = await createToken(user.id, user.email);
+    logger.info(`JWT token for "${user.name}" (id: ${user.id}):\n\t${token}`);
     process.exit(0);
   } catch (err) {
     logger.error('Error creating token for user: ', err.name, err.message);

--- a/packages/backend-api/src/domain/articles/countDenormalization.ts
+++ b/packages/backend-api/src/domain/articles/countDenormalization.ts
@@ -75,8 +75,8 @@ export async function denormalizeCommentCountsForArticle(article: IArticleInstan
 
   await article.update(update);
 
-  if (article.get('categoryId')) {
-    const category = (await Category.findById(article.get('categoryId')))!;
+  if (article.categoryId) {
+    const category = (await Category.findById(article.categoryId))!;
     await denormalizeCommentCountsForCategory(category);
   }
 

--- a/packages/backend-api/src/domain/commentScores/index.ts
+++ b/packages/backend-api/src/domain/commentScores/index.ts
@@ -48,19 +48,19 @@ export interface ITopScores {
  */
 export function calculateTopScore(scores: Array<ICommentScoreInstance>): ICommentScoreInstance | null {
   const scoresWithRange = scores.filter((s) => {
-    return s.get('annotationStart') !== null && s.get('annotationEnd') !== null;
+    return s.annotationStart !== null && s.annotationEnd !== null;
   });
 
   if (scoresWithRange.length <= 0) { return null; }
 
-  return maxBy(scoresWithRange, (s) => s.get('score')) || null;
+  return maxBy(scoresWithRange, (s) => s.score) || null;
 }
 
 /**
  * Get all the scores for a set of comments.
  */
 export async function calculateTopScores(comments: Array<ICommentInstance>, tagId: number): Promise<ITopScores> {
-  return await Bluebird.reduce(comments, async (sum, comment) => {
+  return Bluebird.reduce(comments, async (sum, comment) => {
     const topScore = await CommentTopScore.findOne({
       where: {
         commentId: comment.id,
@@ -70,15 +70,15 @@ export async function calculateTopScores(comments: Array<ICommentInstance>, tagI
 
     if (!topScore) { return sum; }
 
-    const score = await CommentScore.findById(topScore.get('commentScoreId'));
+    const score = await CommentScore.findById(topScore.commentScoreId);
 
     if (!score) { return sum; }
 
     sum[comment.id] = {
-      commentId: score.get('commentId'),
-      score: score.get('score'),
-      start: score.get('annotationStart'),
-      end: score.get('annotationEnd'),
+      commentId: score.commentId,
+      score: score.score,
+      start: score.annotationStart,
+      end: score.annotationEnd,
     };
 
     return sum;

--- a/packages/backend-api/src/domain/comments/textSizes.ts
+++ b/packages/backend-api/src/domain/comments/textSizes.ts
@@ -92,7 +92,7 @@ function wordWrap(text: string, wordWrapWidth: number): Array<string> {
 }
 
 export async function calculateTextSize(comment: ICommentInstance, width: number): Promise<number> {
-  const lines = await wordWrap(comment.get('text'), width);
+  const lines = await wordWrap(comment.text, width);
 
   return getTextHeight(lines, width, TYPE_DEF);
 }

--- a/packages/backend-api/src/integrations/decisions.ts
+++ b/packages/backend-api/src/integrations/decisions.ts
@@ -52,7 +52,9 @@ export async function foreachPendingDecision(
 }
 
 export async function markDecisionExecuted(decision: IDecisionInstance) {
-  decision.set('sentBackToPublisher', sequelize.fn('now')).save();
+  decision.sentBackToPublisher = sequelize.fn('now');
+  await decision.save();
   const comment = (await decision.getComment())!;
-  comment.set('sentBackToPublisher', sequelize.fn('now')).save();
+  comment.sentBackToPublisher = sequelize.fn('now');
+  await comment.save();
 }

--- a/packages/backend-api/src/integrations/youtube/actions.ts
+++ b/packages/backend-api/src/integrations/youtube/actions.ts
@@ -25,7 +25,7 @@ export async function youtubeActivateChannel(
   args: {[key: string]: boolean},
 ) {
   await for_one_youtube_user(owner, async (_, auth) => {
-    await activate_channel(owner, auth, await channel.get('sourceId'), args.activate);
+    await activate_channel(owner, auth, channel.sourceId!, args.activate);
   });
 }
 
@@ -38,7 +38,7 @@ export async function youtubeSynchronizeChannel(
     await sync_comment_threads_for_channel(
       owner,
       auth,
-      await channel.get('sourceId'),
+      channel.sourceId!,
       articleIdMap,
       true,
       1000,

--- a/packages/backend-api/src/integrations/youtube/authenticate.ts
+++ b/packages/backend-api/src/integrations/youtube/authenticate.ts
@@ -33,8 +33,8 @@ export async function for_one_youtube_user(
   }
 
   const oauth2Client = new google.auth.OAuth2(oauthConfig.id, oauthConfig.secret);
-  logger.info(`Youtube: Authenticating as: ${user.id}:${user.get('email')} (${user.get('name')})`);
-  const extra = JSON.parse(user.get('extra'));
+  logger.info(`Youtube: Authenticating as: ${user.id}:${user.email} (${user.name})`);
+  const extra = JSON.parse(user.extra);
   oauth2Client.setCredentials(extra.token);
   await callback(user, oauth2Client);
 }

--- a/packages/backend-api/src/integrations/youtube/channels.ts
+++ b/packages/backend-api/src/integrations/youtube/channels.ts
@@ -60,7 +60,7 @@ export async function sync_channels(
   owner: IUserInstance,
   auth: OAuth2Client,
 ) {
-  logger.info(`Syncing channels for user ${owner.get('email')}`);
+  logger.info(`Syncing channels for user ${owner.email}`);
   let next_page;
   do {
     next_page = await sync_page_of_channels(owner, auth, next_page);
@@ -151,7 +151,7 @@ export async function get_article_id_map_for_channel(
 
   const articleIdMap = new Map<string, number>();
   for (const a of articles) {
-    articleIdMap.set(a.get('sourceId'), a.id);
+    articleIdMap.set(a.sourceId, a.id);
   }
   return articleIdMap;
 }
@@ -169,7 +169,7 @@ export async function for_each_active_channel(
   });
 
   for (const category of categories) {
-    const channelId = category.get('sourceId');
+    const channelId = category.sourceId!;
     const articleIdMap = await get_article_id_map_for_channel(category);
     await callback(channelId, articleIdMap);
   }

--- a/packages/backend-api/src/integrations/youtube/comments.ts
+++ b/packages/backend-api/src/integrations/youtube/comments.ts
@@ -121,8 +121,8 @@ export async function implement_moderation_decision(
   comment: ICommentInstance,
   decision: IDecisionInstance,
 ) {
-  const sourceId = comment.get('sourceId') as string;
-  const status = decision.get('status');
+  const sourceId = comment.sourceId;
+  const status = decision.status;
 
   if (status === MODERATION_ACTION_DEFER) {
     logger.info(`Not syncing comment ${comment.id}:${sourceId} - in deferred state`);

--- a/packages/backend-api/src/integrations/youtube/objectmap.ts
+++ b/packages/backend-api/src/integrations/youtube/objectmap.ts
@@ -94,7 +94,7 @@ export async function mapChannelToCategory(owner: IUserInstance, channel: any) {
       title: 'Channel comments',
       text: 'Comments associated with the channel itself.',
       url: 'https://www.youtube.com/channel/' + channelId,
-      sourceCreatedAt: new Date(Date.parse(channel.snippet!.publishedAt!)),
+      sourceCreatedAt: new Date(channel.snippet!.publishedAt!),
     };
     const [article, acreated] = await Article.findOrCreate({
       where: {
@@ -182,7 +182,7 @@ export async function mapVideoItemToArticle(
     title: snippet.title.substring(0, 255),
     text: snippet.description,
     url: 'https://www.youtube.com/watch?v=' + videoId,
-    sourceCreatedAt: new Date(Date.parse(snippet.publishedAt)),
+    sourceCreatedAt: new Date(snippet.publishedAt),
     extra: snippet,
   };
 
@@ -236,7 +236,7 @@ async function mapCommentToComment(
       avatar: ytcomment.snippet.authorProfileImageUrl,
     };
 
-    const sourceCreatedAt = new Date(Date.parse(ytcomment.snippet.publishedAt));
+    const sourceCreatedAt = new Date(ytcomment.snippet.publishedAt);
     const defaults = {
       articleId: articleId,
       authorSourceId: ytcomment.snippet.authorChannelId.value,

--- a/packages/backend-api/src/integrations/youtube/objectmap.ts
+++ b/packages/backend-api/src/integrations/youtube/objectmap.ts
@@ -262,7 +262,8 @@ async function mapCommentToComment(
     if (created) {
       logger.info(`Created comment ${comment.id} (${comment.sourceId})`);
     }
-    else if (Date.parse(comment.sourceCreatedAt! as string) === sourceCreatedAt.getTime()) {
+    else if (Math.floor((comment.sourceCreatedAt as Date).getTime() / 1000) ===
+             Math.floor(sourceCreatedAt.getTime() / 1000)) {
       logger.info(`Comment ${comment.id} (${comment.sourceId}) unchanged`);
       return;
     }

--- a/packages/backend-api/src/integrations/youtube/videos.ts
+++ b/packages/backend-api/src/integrations/youtube/videos.ts
@@ -68,7 +68,7 @@ export async function sync_playlists(
   owner: IUserInstance,
   auth: OAuth2Client,
 ) {
-  logger.info(`Syncing videos for user ${owner.get('email')}.`);
+  logger.info(`Syncing videos for user ${owner.email}.`);
   const categories = await Category.findAll({
     where: {
       ownerId: owner.id,
@@ -78,17 +78,17 @@ export async function sync_playlists(
   });
 
   for (const category of categories) {
-    const channelId = category.get('sourceId');
+    const channelId = category.sourceId!;
 
     const playlist = await get_playlist_for_channel(owner, auth, channelId);
-    logger.info(`Syncing channel ${category.get('label')} (${channelId}/${playlist})`);
+    logger.info(`Syncing channel ${category.label} (${channelId}/${playlist})`);
 
     let next_page;
     do {
       next_page = await sync_page_of_videos(owner, auth, category, playlist, next_page);
     } while (next_page);
 
-    logger.info(`Done sync of ${category.get('label')}.`);
+    logger.info(`Done sync of ${category.label}.`);
   }
 }
 
@@ -145,7 +145,7 @@ export async function sync_known_videos(
   owner: IUserInstance,
   auth: OAuth2Client,
 ) {
-  logger.info(`Syncing known videos for user ${owner.get('email')}.`);
+  logger.info(`Syncing known videos for user ${owner.email}.`);
   const articles = await Article.findAll({
     where: {
       ownerId: owner.id,
@@ -158,7 +158,7 @@ export async function sync_known_videos(
 
   let videoIds: Array<string> = [];
   for (const article of articles) {
-    videoIds.push(await article.get('sourceId'));
+    videoIds.push(article.sourceId);
     if (videoIds.length === 10) {
       await sync_individual_videos(owner, auth, videoIds);
       videoIds = [];

--- a/packages/backend-api/src/models/article.ts
+++ b/packages/backend-api/src/models/article.ts
@@ -18,11 +18,11 @@ import * as Sequelize from 'sequelize';
 
 import { sequelize } from '../sequelize';
 import { ICategoryInstance } from './category';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { updateHappened } from './last_update';
 import { IUserInstance } from './user';
 
-export interface IArticleAttributes {
-  id?: number;
+export interface IArticleAttributes extends IBaseAttributes {
   ownerId?: number;
   sourceId: string;
   categoryId?: number;
@@ -33,29 +33,24 @@ export interface IArticleAttributes {
   isCommentingEnabled: boolean;
   isAutoModerated: boolean;
   extra?: any | null;
-  allCount?: number;
-  unprocessedCount?: number;
-  unmoderatedCount?: number;
-  moderatedCount?: number;
-  highlightedCount?: number;
-  approvedCount?: number;
-  rejectedCount?: number;
-  deferredCount?: number;
-  flaggedCount?: number;
-  batchedCount?: number;
+  allCount: number;
+  unprocessedCount: number;
+  unmoderatedCount: number;
+  moderatedCount: number;
+  highlightedCount: number;
+  approvedCount: number;
+  rejectedCount: number;
+  deferredCount: number;
+  flaggedCount: number;
+  batchedCount: number;
   lastModeratedAt?: string | Date;
 }
 
-export interface IArticleInstance
-    extends Sequelize.Instance<IArticleAttributes> {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-
+export type IArticleInstance = Sequelize.Instance<IArticleAttributes> & IArticleAttributes & IBaseInstance & {
   getCategory: Sequelize.BelongsToGetAssociationMixin<ICategoryInstance>;
   getAssignedModerators: Sequelize.BelongsToManyGetAssociationsMixin<IUserInstance>;
   countAssignedModerators: Sequelize.BelongsToManyCountAssociationsMixin;
-}
+};
 
 /**
  * Article model

--- a/packages/backend-api/src/models/article.ts
+++ b/packages/backend-api/src/models/article.ts
@@ -29,7 +29,7 @@ export interface IArticleAttributes extends IBaseAttributes {
   title: string;
   text: string;
   url: string;
-  sourceCreatedAt: Date | string | null;
+  sourceCreatedAt?: Date | null;
   isCommentingEnabled: boolean;
   isAutoModerated: boolean;
   extra?: any | null;
@@ -43,7 +43,7 @@ export interface IArticleAttributes extends IBaseAttributes {
   deferredCount: number;
   flaggedCount: number;
   batchedCount: number;
-  lastModeratedAt?: string | Date;
+  lastModeratedAt?: Date | null;
 }
 
 export type IArticleInstance = Sequelize.Instance<IArticleAttributes> & IArticleAttributes & IBaseInstance & {

--- a/packages/backend-api/src/models/category.ts
+++ b/packages/backend-api/src/models/category.ts
@@ -15,38 +15,34 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
+
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { IUserInstance } from './user';
 
-export interface ICategoryAttributes {
-  id?: number;
+export interface ICategoryAttributes extends IBaseAttributes {
   label: string;
   ownerId?: number;
   sourceId?: string;
   isActive?: boolean;
   extra?: any;
-  allCount?: number;
-  unprocessedCount?: number;
-  unmoderatedCount?: number;
-  moderatedCount?: number;
-  highlightedCount?: number;
-  approvedCount?: number;
-  rejectedCount?: number;
-  deferredCount?: number;
-  flaggedCount?: number;
-  batchedCount?: number;
+  allCount: number;
+  unprocessedCount: number;
+  unmoderatedCount: number;
+  moderatedCount: number;
+  highlightedCount: number;
+  approvedCount: number;
+  rejectedCount: number;
+  deferredCount: number;
+  flaggedCount: number;
+  batchedCount: number;
 }
 
-export interface ICategoryInstance
-    extends Sequelize.Instance<ICategoryAttributes> {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-
+export type ICategoryInstance = Sequelize.Instance<ICategoryAttributes> & ICategoryAttributes & IBaseInstance & {
   getAssignedModerators: Sequelize.BelongsToManyGetAssociationsMixin<IUserInstance>;
   countAssignedModerators: Sequelize.BelongsToManyCountAssociationsMixin;
   getOwner: Sequelize.BelongsToGetAssociationMixin<IUserInstance>;
-}
+};
 
 /**
  * Category model

--- a/packages/backend-api/src/models/comment.ts
+++ b/packages/backend-api/src/models/comment.ts
@@ -18,6 +18,7 @@ import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
 import { IArticleInstance } from './article';
 import { ICommentSummaryScoreInstance } from './comment_summary_score';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { IDecisionInstance } from './decision';
 
 export interface IAuthorAttributes {
@@ -35,8 +36,7 @@ export interface IFlagSummary {
   [key: string]: Array<number>;
 }
 
-export interface ICommentAttributes {
-  id?: number;
+export interface ICommentAttributes extends IBaseAttributes {
   ownerId?: number;
   sourceId: string;
   articleId: number | null;
@@ -65,15 +65,12 @@ export interface ICommentAttributes {
   maxSummaryScoreTagId?: string | null;
 }
 
-export interface ICommentInstance extends Sequelize.Instance<ICommentAttributes> {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
+export type ICommentInstance = Sequelize.Instance<ICommentAttributes> & ICommentAttributes & IBaseInstance & {
   getArticle: Sequelize.BelongsToGetAssociationMixin<IArticleInstance>;
   getDecisions: Sequelize.HasManyGetAssociationsMixin<IDecisionInstance>;
   getCommentSummaryScores: Sequelize.HasManyGetAssociationsMixin<ICommentSummaryScoreInstance>;
   getReplyTo: Sequelize.BelongsToGetAssociationMixin<ICommentInstance>;
-}
+};
 
 /**
  * Comment model

--- a/packages/backend-api/src/models/comment.ts
+++ b/packages/backend-api/src/models/comment.ts
@@ -57,7 +57,7 @@ export interface ICommentAttributes extends IBaseAttributes {
   isAutoResolved?: boolean | null;
   unresolvedFlagsCount?: number;
   flagsSummary?: string | IFlagSummary;
-  sourceCreatedAt: Date | string | null | Sequelize.fn;
+  sourceCreatedAt: Date | null | Sequelize.fn;
   sentForScoring?: string | null | Sequelize.fn;
   sentBackToPublisher?: Date | null | Sequelize.fn;
   extra?: any | null;

--- a/packages/backend-api/src/models/comment_flag.ts
+++ b/packages/backend-api/src/models/comment_flag.ts
@@ -18,10 +18,10 @@ import * as Sequelize from 'sequelize';
 
 import { sequelize } from '../sequelize';
 import { Comment } from './comment';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { User } from './user';
 
-export interface ICommentFlagAttributes {
-  id?: number;
+export interface ICommentFlagAttributes extends IBaseAttributes {
   label: string;
   detail?: string;
   isRecommendation: boolean;
@@ -34,11 +34,7 @@ export interface ICommentFlagAttributes {
   extra?: any;
 }
 
-export interface ICommentFlagInstance extends Sequelize.Instance<ICommentFlagAttributes> {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-}
+export type ICommentFlagInstance = Sequelize.Instance<ICommentFlagAttributes> & ICommentFlagAttributes & IBaseInstance;
 
 /**
  * CommentFlag model

--- a/packages/backend-api/src/models/comment_flag.ts
+++ b/packages/backend-api/src/models/comment_flag.ts
@@ -30,7 +30,7 @@ export interface ICommentFlagAttributes extends IBaseAttributes {
   authorSourceId?: string;
   isResolved: boolean;
   resolvedById?: number;
-  resolvedAt?: Date | string;
+  resolvedAt?: Date | null;
   extra?: any;
 }
 

--- a/packages/backend-api/src/models/comment_score.ts
+++ b/packages/backend-api/src/models/comment_score.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
 import { ICommentInstance } from './comment';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { ITagInstance } from './tag';
 
 export const SCORE_SOURCE_TYPES = [
@@ -25,8 +26,7 @@ export const SCORE_SOURCE_TYPES = [
   'Machine',
 ];
 
-export interface ICommentScoreAttributes {
-  id?: number;
+export interface ICommentScoreAttributes extends IBaseAttributes {
   commentId: number | null;
   confirmedUserId?: number;
   commentScoreRequestId?: number;
@@ -41,14 +41,11 @@ export interface ICommentScoreAttributes {
   extra?: any | null;
 }
 
-export interface ICommentScoreInstance extends Sequelize.Instance<ICommentScoreAttributes> {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-
+export type ICommentScoreInstance = Sequelize.Instance<ICommentScoreAttributes> &
+  ICommentScoreAttributes & IBaseInstance & {
   getComment: Sequelize.BelongsToGetAssociationMixin<ICommentInstance>;
   getTag: Sequelize.BelongsToGetAssociationMixin<ITagInstance>;
-}
+};
 
 /**
  * CommentScore model

--- a/packages/backend-api/src/models/comment_score_request.ts
+++ b/packages/backend-api/src/models/comment_score_request.ts
@@ -17,25 +17,20 @@ limitations under the License.
 import * as Sequelize from 'sequelize';
 
 import { sequelize } from '../sequelize';
-import {ICommentInstance} from './comment';
+import { ICommentInstance } from './comment';
+import { IBaseAttributes, IBaseInstance } from './constants';
 
-export interface ICommentScoreRequestAttributes {
-  id?: number;
+export interface ICommentScoreRequestAttributes extends IBaseAttributes {
   commentId: number;
   userId: number;
-  sentAt: Date | string | Sequelize.fn;
-  doneAt?: Date | string | null | Sequelize.fn;
+  sentAt: Date | Sequelize.fn;
+  doneAt?: Date | Sequelize.fn | null;
 }
 
-export interface ICommentScoreRequestInstance
-    extends Sequelize.Instance<
-      ICommentScoreRequestAttributes
-    > {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
+export type ICommentScoreRequestInstance = Sequelize.Instance<ICommentScoreRequestAttributes> &
+  ICommentScoreRequestAttributes & IBaseInstance & {
   getComment: Sequelize.BelongsToGetAssociationMixin<ICommentInstance>;
-}
+};
 
 /**
  * CommentScoreRequest model

--- a/packages/backend-api/src/models/comment_size.ts
+++ b/packages/backend-api/src/models/comment_size.ts
@@ -16,19 +16,16 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 
-export interface ICommentSizeAttributes {
-  id?: number;
+export interface ICommentSizeAttributes extends IBaseAttributes {
   commentId: number;
   width: number;
   height: number;
 }
 
-export interface ICommentSizeInstance
-    extends Sequelize.Instance<ICommentSizeAttributes> {
-  createdAt: string;
-  updatedAt: string;
-}
+export type ICommentSizeInstance = Sequelize.Instance<ICommentSizeAttributes> &
+  ICommentSizeAttributes & IBaseInstance;
 
 /**
  * Category model

--- a/packages/backend-api/src/models/comment_summary_score.ts
+++ b/packages/backend-api/src/models/comment_summary_score.ts
@@ -15,11 +15,12 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
+
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { ITagInstance } from './tag';
 
-export interface ICommentSummaryScoreAttributes {
-  id?: number;
+export interface ICommentSummaryScoreAttributes extends IBaseAttributes{
   commentId: number;
   tagId: number;
   score: number;
@@ -27,8 +28,8 @@ export interface ICommentSummaryScoreAttributes {
   confirmedUserId?: number | null;
 }
 
-export interface ICommentSummaryScoreInstance
-    extends Sequelize.Instance<ICommentSummaryScoreAttributes> {
+export type ICommentSummaryScoreInstance = Sequelize.Instance<ICommentSummaryScoreAttributes> &
+  ICommentSummaryScoreAttributes & IBaseInstance & {
   getTag: Sequelize.BelongsToGetAssociationMixin<ITagInstance>;
 }
 

--- a/packages/backend-api/src/models/comment_top_score.ts
+++ b/packages/backend-api/src/models/comment_top_score.ts
@@ -15,18 +15,18 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
-import { sequelize } from '../sequelize';
 
-export interface ICommentTopScoreAttributes {
-  id?: number;
+import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
+
+export interface ICommentTopScoreAttributes extends IBaseAttributes {
   commentId: number;
   tagId: number;
   commentScoreId: number;
 }
 
-export interface ICommentTopScoreInstance
-    extends Sequelize.Instance<ICommentTopScoreAttributes> {
-}
+export type ICommentTopScoreInstance = Sequelize.Instance<ICommentTopScoreAttributes> &
+  ICommentTopScoreAttributes & IBaseInstance;
 
 /**
  * Category model

--- a/packages/backend-api/src/models/configuration.ts
+++ b/packages/backend-api/src/models/configuration.ts
@@ -26,18 +26,16 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
+import {IBaseInstance} from './constants';
 
 export const CONFIGURATION_TOKEN = 'token';
 export const CONFIGURATION_GOOGLE_OAUTH = 'google-oauth';
 
 interface IConfigurationAttributes {
-  id?: string;
-  createdAt?: string;
-  updatedAt?: string;
   data: any;
 }
 
-type IConfigurationInstance = Sequelize.Instance<IConfigurationAttributes> & IConfigurationAttributes;
+type IConfigurationInstance = Sequelize.Instance<IConfigurationAttributes> & IConfigurationAttributes & IBaseInstance;
 
 const Configuration = sequelize.define<IConfigurationInstance, IConfigurationAttributes>('configuration_items', {
   id: {

--- a/packages/backend-api/src/models/configuration.ts
+++ b/packages/backend-api/src/models/configuration.ts
@@ -31,13 +31,13 @@ export const CONFIGURATION_TOKEN = 'token';
 export const CONFIGURATION_GOOGLE_OAUTH = 'google-oauth';
 
 interface IConfigurationAttributes {
+  id?: string;
+  createdAt?: string;
+  updatedAt?: string;
   data: any;
 }
 
-interface IConfigurationInstance extends Sequelize.Instance<IConfigurationAttributes> {
-  id: number;
-  updatedAt: string;
-}
+type IConfigurationInstance = Sequelize.Instance<IConfigurationAttributes> & IConfigurationAttributes;
 
 const Configuration = sequelize.define<IConfigurationInstance, IConfigurationAttributes>('configuration_items', {
   id: {
@@ -67,6 +67,7 @@ export async function setConfigItem(itemId: string, data: object): Promise<void>
   });
 
   if (!created) {
-    await item.set('data', data).save();
+    item.data = data;
+    await item.save();
   }
 }

--- a/packages/backend-api/src/models/configuration.ts
+++ b/packages/backend-api/src/models/configuration.ts
@@ -26,16 +26,20 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
-import {IBaseInstance} from './constants';
 
 export const CONFIGURATION_TOKEN = 'token';
 export const CONFIGURATION_GOOGLE_OAUTH = 'google-oauth';
 
 interface IConfigurationAttributes {
+  id?: string;
   data: any;
 }
 
-type IConfigurationInstance = Sequelize.Instance<IConfigurationAttributes> & IConfigurationAttributes & IBaseInstance;
+type IConfigurationInstance = Sequelize.Instance<IConfigurationAttributes> & IConfigurationAttributes & {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
 const Configuration = sequelize.define<IConfigurationInstance, IConfigurationAttributes>('configuration_items', {
   id: {

--- a/packages/backend-api/src/models/constants.ts
+++ b/packages/backend-api/src/models/constants.ts
@@ -22,3 +22,24 @@ export const MODERATION_ACTION_HIGHLIGHT = 'Highlight';
 export type IResolution = 'Accept' | 'Reject' | 'Defer';
 
 export type IAction = 'Accept' | 'Reject' | 'Defer' | 'Highlight';
+
+export interface IBaseInstance {
+  id: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IBaseAttributes = Partial<IBaseInstance>;
+
+export const RESET_COUNTS = {
+  allCount: 0,
+  unprocessedCount: 0,
+  moderatedCount: 0,
+  unmoderatedCount: 0,
+  highlightedCount: 0,
+  approvedCount: 0,
+  rejectedCount: 0,
+  deferredCount: 0,
+  flaggedCount: 0,
+  batchedCount: 0,
+};

--- a/packages/backend-api/src/models/csrf.ts
+++ b/packages/backend-api/src/models/csrf.ts
@@ -16,19 +16,15 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 
-export interface ICSRFAttributes {
-  id?: number;
+export interface ICSRFAttributes extends IBaseAttributes {
   clientCSRF: string;
   serverCSRF: string;
   referrer: string | null;
 }
 
-export interface ICSRFInstance extends Sequelize.Instance<ICSRFAttributes> {
-  id: number;
-  createdAt: Date;
-  updatedAt: Date;
-}
+export type ICSRFInstance = Sequelize.Instance<ICSRFAttributes> & ICSRFAttributes & IBaseInstance;
 
 /**
  * CSRF model

--- a/packages/backend-api/src/models/decision.ts
+++ b/packages/backend-api/src/models/decision.ts
@@ -23,9 +23,9 @@ import {
   MODERATION_ACTION_DEFER,
   MODERATION_ACTION_REJECT,
 } from './constants';
+import { IBaseAttributes, IBaseInstance } from './constants';
 
-export interface IDecisionAttributes {
-  id?: number;
+export interface IDecisionAttributes extends IBaseAttributes {
   commentId?: number;
   userId?: number;
   moderationRuleId?: number;
@@ -35,14 +35,9 @@ export interface IDecisionAttributes {
   sentBackToPublisher?: Date | string | Sequelize.fn;
 }
 
-export interface IDecisionInstance
-    extends Sequelize.Instance<IDecisionAttributes> {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-
+export type IDecisionInstance = Sequelize.Instance<IDecisionAttributes> & IDecisionAttributes & IBaseInstance & {
   getComment: Sequelize.BelongsToGetAssociationMixin<ICommentInstance>;
-}
+};
 
 /**
  * Decision model

--- a/packages/backend-api/src/models/last_update.ts
+++ b/packages/backend-api/src/models/last_update.ts
@@ -16,17 +16,13 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 
-export interface ILastUpdateAttributes {
-  id: number;
+export interface ILastUpdateAttributes extends IBaseAttributes {
   lastUpdate: number;
 }
 
-export interface ILastUpdateInstance
-  extends Sequelize.Instance<ILastUpdateAttributes> {
-  id: number;
-  updatedAt: string;
-}
+export type ILastUpdateInstance = Sequelize.Instance<ILastUpdateAttributes> & ILastUpdateAttributes & IBaseInstance;
 
 /**
  * Category model
@@ -61,8 +57,8 @@ async function getInstance() {
 
 async function updateLastUpdate() {
   const instance = await getInstance();
-  lastUpdateLocal = instance.get('lastUpdate') + 1;
-  instance.set('lastUpdate', lastUpdateLocal);
+  lastUpdateLocal = instance.lastUpdate + 1;
+  instance.lastUpdate = lastUpdateLocal;
   await instance.save();
 }
 export async function partialUpdateHappened(articleId: number) {
@@ -91,7 +87,7 @@ export function registerInterest(interestListener: IInterestListener, testing = 
 // Exporting for test purposes, but should really be unexported
 export async function maybeNotifyInterested() {
   const instance = await getInstance();
-  const lastUpdate = instance.get('lastUpdate');
+  const lastUpdate = instance.lastUpdate;
   if (lastUpdate !== lastUpdateLocal) {
     lastUpdateLocal = lastUpdate;
     for (const i of interested) {

--- a/packages/backend-api/src/models/moderation_rule.ts
+++ b/packages/backend-api/src/models/moderation_rule.ts
@@ -24,6 +24,7 @@ import {
   MODERATION_ACTION_HIGHLIGHT,
   MODERATION_ACTION_REJECT,
 } from './constants';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { updateHappened } from './last_update';
 
 export const MODERATION_RULE_ACTION_TYPES = [
@@ -33,7 +34,7 @@ export const MODERATION_RULE_ACTION_TYPES = [
   MODERATION_ACTION_HIGHLIGHT,
 ];
 
-export interface IModerationRuleAttributes {
+export interface IModerationRuleAttributes extends IBaseAttributes {
   tagId: number;
   categoryId?: number;
   createdBy?: number;
@@ -42,14 +43,8 @@ export interface IModerationRuleAttributes {
   action: IAction;
 }
 
-export interface IModerationRuleInstance
-    extends Sequelize.Instance<
-      IModerationRuleAttributes
-    > {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-}
+export type IModerationRuleInstance = Sequelize.Instance<IModerationRuleAttributes> &
+  IModerationRuleAttributes & IBaseInstance;
 
 /**
  * ModerationRule model
@@ -131,5 +126,5 @@ export function isModerationRule(instance: any) {
   //       Hopefully fixed in later sequelize.
   //       Instead check for an attribute unique to this object.
   // return instance instanceof ModerationRule.Instance;
-  return instance && instance.get && !!instance.get('action');
+  return instance && instance.get && !!instance.action;
 }

--- a/packages/backend-api/src/models/moderator_assignment.ts
+++ b/packages/backend-api/src/models/moderator_assignment.ts
@@ -16,20 +16,15 @@ limitations under the License.
 
 import * as Sequelize from 'sequelize';
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 
-export interface IModeratorAssignmentAttributes {
+export interface IModeratorAssignmentAttributes extends  IBaseAttributes {
   userId: number;
   articleId: number;
 }
 
-export interface IModeratorAssignmentInstance
-    extends Sequelize.Instance<
-      IModeratorAssignmentAttributes
-    > {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-}
+export type IModeratorAssignmentInstance = Sequelize.Instance<IModeratorAssignmentAttributes> &
+  IModeratorAssignmentAttributes & IBaseInstance;
 
 /**
  * Article model

--- a/packages/backend-api/src/models/preselect.ts
+++ b/packages/backend-api/src/models/preselect.ts
@@ -15,11 +15,12 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
+
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { updateHappened } from './last_update';
 
-export interface IPreselectAttributes {
-  id?: number;
+export interface IPreselectAttributes extends IBaseAttributes{
   tagId?: number;
   categoryId?: number;
   createdBy?: number;
@@ -27,14 +28,7 @@ export interface IPreselectAttributes {
   upperThreshold: number;
 }
 
-export interface IPreselectInstance
-    extends Sequelize.Instance<
-      IPreselectAttributes
-    > {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-}
+export type IPreselectInstance = Sequelize.Instance<IPreselectAttributes> & IPreselectAttributes & IBaseInstance;
 
 /**
  * Preselect model

--- a/packages/backend-api/src/models/tag.ts
+++ b/packages/backend-api/src/models/tag.ts
@@ -15,11 +15,12 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
+
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { updateHappened } from './last_update';
 
-export interface ITagAttributes {
-  id?: number;
+export interface ITagAttributes extends IBaseAttributes {
   key: string;
   label: string;
   color?: string;
@@ -29,12 +30,7 @@ export interface ITagAttributes {
   inSummaryScore?: boolean;
 }
 
-export interface ITagInstance
-    extends Sequelize.Instance<ITagAttributes> {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-}
+export type ITagInstance = Sequelize.Instance<ITagAttributes> & ITagAttributes & IBaseInstance;
 
 /**
  * Tag model

--- a/packages/backend-api/src/models/tagging_sensitivity.ts
+++ b/packages/backend-api/src/models/tagging_sensitivity.ts
@@ -15,11 +15,12 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
+
 import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
 import { updateHappened } from './last_update';
 
-export interface ITaggingSensitivityAttributes {
-  id?: number;
+export interface ITaggingSensitivityAttributes extends IBaseAttributes{
   tagId?: number;
   categoryId?: number;
   createdBy?: number;
@@ -27,14 +28,8 @@ export interface ITaggingSensitivityAttributes {
   upperThreshold: number;
 }
 
-export interface ITaggingSensitivityInstance
-    extends Sequelize.Instance<
-      ITaggingSensitivityAttributes
-    > {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-}
+export type ITaggingSensitivityInstance = Sequelize.Instance<ITaggingSensitivityAttributes> &
+  ITaggingSensitivityAttributes & IBaseInstance;
 
 /**
  * TaggingSensitivity model

--- a/packages/backend-api/src/models/user.ts
+++ b/packages/backend-api/src/models/user.ts
@@ -46,6 +46,7 @@ export interface IUserAttributes extends IBaseAttributes {
   email?: string;
   name: string;
   isActive: boolean;
+  avatarURL?: string | null;
   extra?: any;
 }
 

--- a/packages/backend-api/src/models/user_category_assignment.ts
+++ b/packages/backend-api/src/models/user_category_assignment.ts
@@ -15,18 +15,17 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
-import { sequelize } from '../sequelize';
 
-export interface IUserCategoryAssignmentAttributes {
+import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
+
+export interface IUserCategoryAssignmentAttributes extends IBaseAttributes {
   categoryId: number;
   userId: number;
 }
 
-export interface IUserCategoryAssignmentInstance
-    extends Sequelize.Instance<IUserCategoryAssignmentAttributes> {
-  createdAt: string;
-  updatedAt: string;
-}
+export type IUserCategoryAssignmentInstance = Sequelize.Instance<IUserCategoryAssignmentAttributes> &
+  IUserCategoryAssignmentAttributes & IBaseInstance;
 
 /**
  * Category model

--- a/packages/backend-api/src/models/user_social_auth.ts
+++ b/packages/backend-api/src/models/user_social_auth.ts
@@ -15,24 +15,19 @@ limitations under the License.
 */
 
 import * as Sequelize from 'sequelize';
-import { sequelize } from '../sequelize';
 
-export interface IUserSocialAuthAttributes {
-  id?: number;
+import { sequelize } from '../sequelize';
+import { IBaseAttributes, IBaseInstance } from './constants';
+
+export interface IUserSocialAuthAttributes extends IBaseAttributes {
   userId?: number;
   socialId: string;
   provider: string;
   extra?: any;
 }
 
-export interface IUserSocialAuthInstance
-    extends Sequelize.Instance<
-      IUserSocialAuthAttributes
-    > {
-  id: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
+export type IUserSocialAuthInstance = Sequelize.Instance<IUserSocialAuthAttributes> &
+  IUserSocialAuthAttributes & IBaseInstance;
 
 export const UserSocialAuth = sequelize.define<
   IUserSocialAuthInstance,

--- a/packages/backend-api/src/pipeline/apiShim.ts
+++ b/packages/backend-api/src/pipeline/apiShim.ts
@@ -86,7 +86,7 @@ export async function createShim(
     processMachineScore: (commentId: number, serviceUserId: number, scoreData: IScoreData) => Promise<void>,
     ) {
   const serviceUserId = scorer.id;
-  const extra: any = JSON.parse(scorer.get('extra'));
+  const extra: any = JSON.parse(scorer.extra);
   const discoveryURL = extra.endpoint;
   const apiKey = extra.apiKey;
   const attributes = extra.attributes;
@@ -94,7 +94,7 @@ export async function createShim(
 
   async function packPerspectiveApiRequest(comment: ICommentInstance, reqId: string | number) {
     const req: IAnalyzeCommentRequest = {
-      comment: {text: striptags(comment.get('text'))},
+      comment: {text: striptags(comment.text)},
       context: {entries: []},
       requestedAttributes: attributes,
       languages: ['en'],
@@ -104,12 +104,12 @@ export async function createShim(
 
     const article = await comment.getArticle();
     if (article) {
-      req.context.entries.push({text: striptags(article.get('text'))});
+      req.context.entries.push({text: striptags(article.text)});
     }
 
     const replyTo = await comment.getReplyTo();
     if (replyTo) {
-      req.context.entries.push({text: striptags(replyTo.get('text'))});
+      req.context.entries.push({text: striptags(replyTo.text)});
     }
 
     return req;
@@ -134,7 +134,7 @@ export async function createShim(
         if (!unpackedData.scores[unversionedName]) {
           // Not got a spanScores entry, so make one up from the summary
           const begin = 0;
-          const end = comment.get('text').length;
+          const end = comment.text.length;
           const value = attributeScore.summaryScore.value;
           unpackedData.scores[unversionedName] = [{begin, end, score: value}];
         }

--- a/packages/backend-api/src/pipeline/hooks.ts
+++ b/packages/backend-api/src/pipeline/hooks.ts
@@ -34,7 +34,7 @@ async function getOwnerData(ownerId: number) {
     throw new Error(`No user with ID ${ownerId}`);
   }
 
-  const ownerType = owner.get('group');
+  const ownerType = owner.group;
   const hook = hooks.get(ownerType);
   return {owner, ownerType, hook};
 }
@@ -56,7 +56,7 @@ export function registerHooks(ownerType: string, hook: IPipelineHook) {
 }
 
 export async function commentModeratedHook(comment: ICommentInstance) {
-  const ownerId = comment.get('ownerId');
+  const ownerId = comment.ownerId;
   if (!ownerId) {
     return;
   }

--- a/packages/backend-api/src/pipeline/proxyShim.ts
+++ b/packages/backend-api/src/pipeline/proxyShim.ts
@@ -22,7 +22,6 @@ import { rtrim } from 'underscore.string';
 import { config } from '../config';
 import { logger } from '../logger';
 import {
-  Article,
   ICommentInstance,
   IUserInstance,
 } from '../models';
@@ -78,18 +77,18 @@ export function createShim(
     processMachineScore: (commentId: number, serviceUserId: number, scoreData: IScoreData) => Promise<void>,
     ) {
   const serviceUserId = scorer.id;
-  const extra: any = JSON.parse(scorer.get('extra'));
+  const extra: any = JSON.parse(scorer.extra);
   const endpoint = extra.endpoint;
   const apiURL = rtrim(config.get('api_url'), '/');
   const apiKey = extra.apiKey;
 
   return {
     sendToScorer: async (comment: ICommentInstance, correlator: string | number) => {
-      const article = await Article.findById(comment.get('articleId'));
+      const article = await comment.getArticle();
 
       // Ensure data is present, otherwise an error will throw.
       if (!article) {
-        logger.error(`sendToScorer: Article ${comment.get('articleId')} not found for comment ${comment.id}.`);
+        logger.error(`sendToScorer: Article ${comment.articleId} not found for comment ${comment.id}.`);
         throw new Error(`No article for comment ${comment.id}.  Can't score.`);
       }
 
@@ -99,8 +98,8 @@ export function createShim(
 
         comment: {
           commentId: comment.id,
-          plainText: striptags(comment.get('text')),
-          htmlText: comment.get('text'),
+          plainText: striptags(comment.text),
+          htmlText: comment.text,
           links: {
             self: apiURL + '/rest/comments/' + comment.id,
           },
@@ -108,7 +107,7 @@ export function createShim(
 
         article: {
           articleId: article.id,
-          plainText: striptags(article.get('text')),
+          plainText: striptags(article.text),
           links: {
             self: apiURL + '/rest/articles/' + article.id,
           },
@@ -124,8 +123,8 @@ export function createShim(
       if (replyTo) {
         postData.inReplyToComment = {
           commentId: replyTo.id,
-          plainText: striptags(replyTo.get('text')),
-          htmlText: replyTo.get('text'),
+          plainText: striptags(replyTo.text),
+          htmlText: replyTo.text,
           links: {
             self: apiURL + '/rest/comments/' + replyTo.id,
           },

--- a/packages/backend-api/src/pipeline/state.ts
+++ b/packages/backend-api/src/pipeline/state.ts
@@ -65,7 +65,7 @@ export function scoresComplete(commentScoreRequests: Array<ICommentScoreRequestI
         // score requests have `doneAt` set
 
         return grouped[key].some((item: ICommentScoreRequestInstance) => {
-          return !!item.get('doneAt');
+          return !!item.doneAt;
         });
       })
       .every((item: boolean) => {
@@ -250,7 +250,7 @@ export async function highlight(
   source: IUserInstance | IModerationRuleInstance | null,
 ): Promise<ICommentInstance> {
   let updated = comment;
-  if (comment.get('isHighlighted') === true) {
+  if (comment.isHighlighted) {
     updated = await setCommentState(comment, source, {
       ...getApproveStateData(),
       ...getUnHighlightStateData(),

--- a/packages/backend-api/src/processing/tasks/comment_actions.ts
+++ b/packages/backend-api/src/processing/tasks/comment_actions.ts
@@ -89,7 +89,8 @@ async function executeDeferCommentsTask(data: ICommentActionData) {
 
   // update batch action
   logger.info('defer comment : ',  comment.id );
-  await comment.set('isBatchResolved', data.isBatchAction).save();
+  comment.isBatchResolved = data.isBatchAction;
+  await comment.save();
   return defer(comment, user);
 }
 
@@ -98,7 +99,8 @@ async function executeHighlightCommentsTask(data: ICommentActionData)  {
   const comment = await getComment(data.commentId);
 
   logger.info('highlight comment : ', comment.id);
-  await comment.set('isBatchResolved', data.isBatchAction).save();
+  comment.isBatchResolved = data.isBatchAction;
+  await comment.save();
   return highlight(comment, user);
 }
 

--- a/packages/backend-api/src/processing/tasks/db_operations.ts
+++ b/packages/backend-api/src/processing/tasks/db_operations.ts
@@ -80,7 +80,8 @@ export async function resolveComment(
   const user = await getUser(userId);
   const comment = await getComment(commentId);
   logger.info(`${status} comment: ${commentId}`);
-  await comment.set('isBatchResolved', isBatchAction).save();
+  comment.isBatchResolved = isBatchAction
+  await comment.save();
   await domainFn(comment, user);
 }
 

--- a/packages/backend-api/src/processing/tasks/process_tagging.ts
+++ b/packages/backend-api/src/processing/tasks/process_tagging.ts
@@ -69,7 +69,8 @@ export async function executeProcessTagAdditionTask(data: IProcessTagAdditionDat
     const [instance, created] = await CommentFlag.findOrCreate(options);
 
     if (!created) {
-      instance.set('extra', extra).save();
+      instance.extra = extra;
+      await instance.save();
     }
 
     await denormalizeCountsForComment(comment);

--- a/packages/backend-api/src/processing/tasks/score_actions.ts
+++ b/packages/backend-api/src/processing/tasks/score_actions.ts
@@ -79,7 +79,7 @@ async function executeConfirmCommentSummaryScoreTask(data: ITagCommentsData) {
 
   if (!cs) { return; }
 
-  logger.info(`Confirm tag for comment_score commentId: ${cs.get('commentId')}`);
+  logger.info(`Confirm tag for comment_score commentId: ${cs.commentId}`);
 
   return cs.update({
     isConfirmed: true,
@@ -101,7 +101,7 @@ async function executeRejectCommentSummaryScoreTask(data: ITagCommentsData) {
 
   if (!cs) { return; }
 
-  logger.info(`Confirm tag for comment_score commentId: ${cs.get('commentId')}`);
+  logger.info(`Confirm tag for comment_score commentId: ${cs.commentId}`);
 
   return cs.update({
     isConfirmed: false,

--- a/packages/backend-api/src/test/auth/tokens.spec.ts
+++ b/packages/backend-api/src/test/auth/tokens.spec.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import * as chai from 'chai';
 import * as jwt from 'jsonwebtoken';
 import * as moment from 'moment';
-import * as sinon from 'sinon';
 
 import {
   createToken,
@@ -28,6 +27,14 @@ import {
   refreshToken,
   verifyToken,
 } from '../../auth/tokens';
+import {
+  IUserInstance,
+  User,
+  USER_GROUP_ADMIN,
+  USER_GROUP_GENERAL,
+  USER_GROUP_SERVICE,
+} from '../../models';
+import { makeUser } from '../fixture';
 
 const assert = chai.assert;
 
@@ -47,17 +54,19 @@ describe('Auth Domain Token Tests', () => {
       .unix();
   }
 
-  const fakeGeneralUser = {
-    get: sinon.stub().withArgs('group').returns('general'),
-  } as any;
+  let fakeGeneralUser: IUserInstance;
+  let fakeAdminUser: IUserInstance;
+  let fakeServiceUser: IUserInstance;
 
-  const fakeAdminUser = {
-    get: sinon.stub().withArgs('group').returns('admin'),
-  } as any;
+  beforeEach(async () => {
+    fakeGeneralUser = await makeUser({group: USER_GROUP_GENERAL});
+    fakeAdminUser = await makeUser({group: USER_GROUP_ADMIN});
+    fakeServiceUser = await makeUser({group: USER_GROUP_SERVICE});
+  });
 
-  const fakeServiceUser = {
-    get: sinon.stub().withArgs('group').returns('service'),
-  } as any;
+  afterEach(async () => {
+    await User.destroy({where: {}});
+  });
 
   describe('isExpired', () => {
     it('should return false for an unexpired token', async () => {

--- a/packages/backend-api/src/test/auth/users.spec.ts
+++ b/packages/backend-api/src/test/auth/users.spec.ts
@@ -81,10 +81,10 @@ describe('Auth Domain Users Tests', function() {
       const [userSocialAuth, created] = await findOrCreateUserSocialAuth(createdUser, userSocialAuthData);
 
       assert.isTrue(created);
-      assert.equal(userSocialAuth.get('userId'), createdUser.id);
-      assert.equal(userSocialAuth.get('provider'), userSocialAuthData.provider);
-      assert.equal(userSocialAuth.get('socialId'), userSocialAuthData.socialId);
-      assert.deepEqual(userSocialAuth.get('extra'), userSocialAuthData.extra);
+      assert.equal(userSocialAuth.userId, createdUser.id);
+      assert.equal(userSocialAuth.provider, userSocialAuthData.provider);
+      assert.equal(userSocialAuth.socialId, userSocialAuthData.socialId);
+      assert.deepEqual(userSocialAuth.extra, userSocialAuthData.extra);
     });
 
     it('should resolve to an existing social auth if present', async () => {
@@ -116,10 +116,10 @@ describe('Auth Domain Users Tests', function() {
 
       assert.isFalse(created);
       assert.equal(userSocialAuth.id, createdSocialAuth.id);
-      assert.equal(userSocialAuth.get('userId'), createdUser.id);
-      assert.equal(userSocialAuth.get('provider'), userSocialAuthData.provider);
-      assert.equal(userSocialAuth.get('socialId'), userSocialAuthData.socialId);
-      assert.deepEqual(JSON.parse(userSocialAuth.get('extra')), userSocialAuthData.extra);
+      assert.equal(userSocialAuth.userId, createdUser.id);
+      assert.equal(userSocialAuth.provider, userSocialAuthData.provider);
+      assert.equal(userSocialAuth.socialId, userSocialAuthData.socialId);
+      assert.deepEqual(JSON.parse(userSocialAuth.extra), userSocialAuthData.extra);
     });
 
     it('should not allow multiple social auth records for the same user from the same provider', async () => {
@@ -159,7 +159,7 @@ describe('Auth Domain Users Tests', function() {
       const [createdSocialAuth1, created] = await findOrCreateUserSocialAuth(createdUser1, userSocialAuthData1);
 
       assert.isTrue(created);
-      assert.equal(createdUser1.id, createdSocialAuth1.get('userId'));
+      assert.equal(createdUser1.id, createdSocialAuth1.userId);
 
       try {
         await findOrCreateUserSocialAuth(createdUser2, userSocialAuthData2);
@@ -201,9 +201,9 @@ describe('Auth Domain Users Tests', function() {
 
     async function assertUser(user: any) {
       const dbu = (await User.findOne({where: {email: user.email}}))!;
-      assert.equal(dbu.get('name'), user.name);
-      assert.equal(dbu.get('group'), user.group);
-      assert.equal(dbu.get('isActive'), user.isActive);
+      assert.equal(dbu.name, user.name);
+      assert.equal(dbu.group, user.group);
+      assert.equal(dbu.isActive, user.isActive);
     }
 
     it('Make sure nothing happens if we already have a first user', async () => {

--- a/packages/backend-api/src/test/domain/comments/fixture.ts
+++ b/packages/backend-api/src/test/domain/comments/fixture.ts
@@ -26,6 +26,7 @@ import {
   CommentScoreRequest,
   CommentSummaryScore,
   ModerationRule,
+  RESET_COUNTS,
   Tag,
   User,
 } from '../../../models';
@@ -62,6 +63,7 @@ import { sequelize } from '../../../sequelize';
 export function getCategoryData(data: Partial<ICategoryAttributes> = {}): ICategoryAttributes {
   return {
     label: faker.lorem.words(1),
+    ...RESET_COUNTS,
     ...data,
   };
 }
@@ -80,6 +82,7 @@ export function getArticleData(data: Partial<IArticleAttributes> = {}): IArticle
     sourceCreatedAt: '2012-10-29T21:54:07.609Z',
     isCommentingEnabled: true,
     isAutoModerated: true,
+    ...RESET_COUNTS,
     ...data,
   };
 }

--- a/packages/backend-api/src/test/domain/comments/fixture.ts
+++ b/packages/backend-api/src/test/domain/comments/fixture.ts
@@ -79,7 +79,7 @@ export function getArticleData(data: Partial<IArticleAttributes> = {}): IArticle
     title: faker.lorem.words(20),
     text: faker.lorem.words(20),
     url: faker.internet.url(),
-    sourceCreatedAt: '2012-10-29T21:54:07.609Z',
+    sourceCreatedAt: new Date('2012-10-29T21:54:07.609Z'),
     isCommentingEnabled: true,
     isAutoModerated: true,
     ...RESET_COUNTS,

--- a/packages/backend-api/src/test/fixture.ts
+++ b/packages/backend-api/src/test/fixture.ts
@@ -18,7 +18,7 @@ import * as chai from 'chai';
 import * as WebSocket from 'ws';
 
 import {
-  MODERATION_ACTION_ACCEPT,
+  MODERATION_ACTION_ACCEPT, RESET_COUNTS,
 } from '../models';
 import {
   IArticleInstance,
@@ -61,15 +61,7 @@ export async function makeArticle(obj = {}): Promise<IArticleInstance> {
     sourceCreatedAt: '2012-10-29T21:54:07.609Z',
     isCommentingEnabled: true,
     isAutoModerated: true,
-    unprocessedCount: 0,
-    unmoderatedCount: 0,
-    moderatedCount: 0,
-    highlightedCount: 0,
-    approvedCount: 0,
-    rejectedCount: 0,
-    deferredCount: 0,
-    flaggedCount: 0,
-    batchedCount: 0,
+    ...RESET_COUNTS,
     ...obj,
   });
 }
@@ -79,6 +71,7 @@ export async function makeUser(obj = {}): Promise<IUserInstance> {
     group: 'general',
     name: 'Name',
     email: 'email@example.com',
+    isActive: true,
     ...obj,
   });
 }
@@ -138,15 +131,7 @@ export async function makeCommentSummaryScore(obj: Pick<ICommentSummaryScoreAttr
 export async function makeCategory(obj = {}): Promise<ICategoryInstance> {
   return await Category.create({
     label: 'something',
-    unprocessedCount: 0,
-    unmoderatedCount: 0,
-    moderatedCount: 0,
-    highlightedCount: 0,
-    approvedCount: 0,
-    rejectedCount: 0,
-    deferredCount: 0,
-    flaggedCount: 0,
-    batchedCount: 0,
+    ...RESET_COUNTS,
     ...obj,
   });
 }

--- a/packages/backend-api/src/test/fixture.ts
+++ b/packages/backend-api/src/test/fixture.ts
@@ -58,7 +58,7 @@ export async function makeArticle(obj = {}): Promise<IArticleInstance> {
     title: 'An article',
     text: 'Text',
     url: 'https://example.com',
-    sourceCreatedAt: '2012-10-29T21:54:07.609Z',
+    sourceCreatedAt: new Date('2012-10-29T21:54:07.609Z'),
     isCommentingEnabled: true,
     isAutoModerated: true,
     ...RESET_COUNTS,
@@ -103,7 +103,7 @@ export async function makeComment(obj = {}): Promise<ICommentInstance> {
       name: 'Joe Bloggs',
     },
     unresolvedFlagsCount: 0,
-    sourceCreatedAt: '2012-10-29T21:54:07.609Z',
+    sourceCreatedAt: new Date('2012-10-29T21:54:07.609Z'),
     isScored: true,
     ...obj,
   });

--- a/packages/backend-api/src/test/integration/api/actions.spec.ts
+++ b/packages/backend-api/src/test/integration/api/actions.spec.ts
@@ -63,10 +63,10 @@ describe(BASE_URL, () => {
     flagsCount: number,
   ) {
     const a1 = (await Article.findById(article.id))!;
-    expect(a1.get('unmoderatedCount'), `${x} article newCount`).equal(newCount);
-    expect(a1.get('approvedCount'), `${x} article approvedCount`).equal(approvedCount);
-    expect(a1.get('rejectedCount'), `${x} article rejectedCount`).equal(rejectedCount);
-    expect(a1.get('flaggedCount'), `${x} article flaggedCount`).equal(flagsCount);
+    expect(a1.unmoderatedCount, `${x} article newCount`).equal(newCount);
+    expect(a1.approvedCount, `${x} article approvedCount`).equal(approvedCount);
+    expect(a1.rejectedCount, `${x} article rejectedCount`).equal(rejectedCount);
+    expect(a1.flaggedCount, `${x} article flaggedCount`).equal(flagsCount);
   }
 
   async function checkComment(
@@ -78,22 +78,22 @@ describe(BASE_URL, () => {
   ) {
     const c = (await Comment.findById(id))!;
     if (state === 'new') {
-      expect(c.get('isModerated'), `${x} comment ${id} is moderated`).equal(false);
+      expect(c.isModerated, `${x} comment ${id} is moderated`).equal(false);
     }
     else {
-      expect(c.get('isModerated'), `${x} comment ${id} is moderated`).equal(true);
-      expect(c.get('isAccepted'),  `${x} comment ${id} is accepted`).equal(state === 'accepted');
+      expect(c.isModerated, `${x} comment ${id} is moderated`).equal(true);
+      expect(c.isAccepted,  `${x} comment ${id} is accepted`).equal(state === 'accepted');
     }
 
-    expect(c.get('unresolvedFlagsCount'), `${x} comment ${id} unresolved`).equals(unresolved);
-    const s = JSON.parse(c.get('flagsSummary'));
+    expect(c.unresolvedFlagsCount, `${x} comment ${id} unresolved`).equals(unresolved);
+    const s = JSON.parse(c.flagsSummary! as string);
     expect(s, `${x} comment ${id} summary`).deep.equal(summary);
   }
 
   async function checkFlag(x: string, id: number, resolved: boolean, resolvedById: number | null) {
     const f = (await CommentFlag.findById(id))!;
-    expect(f.get('isResolved'), `${x} flag ${id} isResolved`).equal(resolved);
-    expect(f.get('resolvedById'), `${x} flag ${id} resolvedById`).equal(resolvedById);
+    expect(f.isResolved, `${x} flag ${id} isResolved`).equal(resolved);
+    expect(f.resolvedById, `${x} flag ${id} resolvedById`).equal(resolvedById);
   }
 
   async function actOnAComment(url: string) {

--- a/packages/backend-api/src/test/integration/api/editComment.spec.ts
+++ b/packages/backend-api/src/test/integration/api/editComment.spec.ts
@@ -88,10 +88,10 @@ describe(URL, () => {
             });
 
             const updatedComment = await Comment.findOne({ where: { id: comment.id }});
-            const { name, location } = JSON.parse(updatedComment!.get('author'));
+            const { name, location } = JSON.parse(updatedComment!.author as string);
 
             expect(status).to.be.equal(200);
-            expect(updatedComment!.get('text')).to.be.equal(updatedText);
+            expect(updatedComment!.text).to.be.equal(updatedText);
             expect(name).to.be.equal(updatedAuthorName);
             expect(location).to.be.equal(updatedAuthorLocation);
 

--- a/packages/backend-api/src/test/integration/api/histogramScores.spec.ts
+++ b/packages/backend-api/src/test/integration/api/histogramScores.spec.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import * as chai from 'chai';
 
-
 import { cacheCommentTopScores } from '../../../domain';
 import {
   Article,
@@ -76,12 +75,12 @@ describe(BASE_URL, () => {
 
       expect(body.data).to.deep.include({
         commentId: comment1.id.toString(),
-        score: commentSummaryScore1.get('score'),
+        score: commentSummaryScore1.score,
       });
 
       expect(body.data).to.deep.include({
         commentId: comment2.id.toString(),
-        score: commentSummaryScore2.get('score'),
+        score: commentSummaryScore2.score,
       });
     });
 
@@ -155,12 +154,12 @@ describe(BASE_URL, () => {
 
       expect(body.data).to.deep.include({
         commentId: comment1.id.toString(),
-        score: commentSummaryScore1.get('score'),
+        score: commentSummaryScore1.score,
       });
 
       expect(body.data).to.deep.include({
         commentId: comment2.id.toString(),
-        score: commentSummaryScore2.get('score'),
+        score: commentSummaryScore2.score,
       });
     });
 

--- a/packages/backend-api/src/test/integration/api/publisher.spec.ts
+++ b/packages/backend-api/src/test/integration/api/publisher.spec.ts
@@ -164,7 +164,7 @@ describe('Publisher API', () => {
     describe('/articles/:sourceId', () => {
       it('should update an article', async () => {
         const article = await makeArticle({ title: 'Title One' });
-        const url = prefixed(`articles/${article.get('sourceId')}`);
+        const url = prefixed(`articles/${article.sourceId}`);
 
         let was200 = false;
 
@@ -181,9 +181,9 @@ describe('Publisher API', () => {
           expect(status).to.be.equal(200);
           was200 = true;
 
-          const updatedArticle = (await Article.findOne({ where: { sourceId: article.get('sourceId') }}))!;
+          const updatedArticle = (await Article.findOne({ where: { sourceId: article.sourceId }}))!;
 
-          expect(updatedArticle.get('title')).to.equal('Title Two');
+          expect(updatedArticle.title).to.equal('Title Two');
         } finally {
           expect(was200).to.be.true;
         }

--- a/packages/backend-api/src/test/pipeline/pipeline.spec.ts
+++ b/packages/backend-api/src/test/pipeline/pipeline.spec.ts
@@ -211,43 +211,43 @@ describe('Pipeline Tests', () => {
       // Assertions against test data
 
       for (const score of scores) {
-        assert.equal(score.get('sourceType'), 'Machine');
-        assert.equal(score.get('userId'), serviceUser.id);
+        assert.equal(score.sourceType, 'Machine');
+        assert.equal(score.userId, serviceUser.id);
 
-        if (score.get('score') === 0.2) {
-          assert.equal(score.get('annotationStart'), 0);
-          assert.equal(score.get('annotationEnd'), 62);
-          assert.equal((await score.getTag())!.get('key'), 'ATTACK_ON_COMMENTER');
+        if (score.score === 0.2) {
+          assert.equal(score.annotationStart, 0);
+          assert.equal(score.annotationEnd, 62);
+          assert.equal((await score.getTag())!.key, 'ATTACK_ON_COMMENTER');
         }
 
-        if (score.get('score') === 0.4) {
-          assert.equal(score.get('annotationStart'), 0);
-          assert.equal(score.get('annotationEnd'), 62);
-          assert.equal((await score.getTag())!.get('key'), 'INFLAMMATORY');
+        if (score.score === 0.4) {
+          assert.equal(score.annotationStart, 0);
+          assert.equal(score.annotationEnd, 62);
+          assert.equal((await score.getTag())!.key, 'INFLAMMATORY');
         }
 
-        if (score.get('score') === 0.7) {
-          assert.equal(score.get('annotationStart'), 63);
-          assert.equal(score.get('annotationEnd'), 66);
-          assert.equal((await score.getTag())!.get('key'), 'INFLAMMATORY');
+        if (score.score === 0.7) {
+          assert.equal(score.annotationStart, 63);
+          assert.equal(score.annotationEnd, 66);
+          assert.equal((await score.getTag())!.key, 'INFLAMMATORY');
         }
       }
 
       for (const score of summaryScores) {
-        if (score.get('score') === 0.2) {
-          assert.equal((await score.getTag())!.get('key'), 'ATTACK_ON_COMMENTER');
+        if (score.score === 0.2) {
+          assert.equal((await score.getTag())!.key, 'ATTACK_ON_COMMENTER');
         }
 
-        if (score.get('score') === 0.55) {
-          assert.equal((await score.getTag())!.get('key'), 'INFLAMMATORY');
+        if (score.score === 0.55) {
+          assert.equal((await score.getTag())!.key, 'INFLAMMATORY');
         }
       }
 
       // Request assertions
       assert.isNotNull(request);
-      assert.isOk(request!.get('doneAt'));
-      assert.equal(request!.get('commentId'), comment.id);
-      assert.isTrue((await request!.getComment())!.get('isScored'));
+      assert.isOk(request!.doneAt);
+      assert.equal(request!.commentId, comment.id);
+      assert.isTrue((await request!.getComment())!.isScored);
     });
 
     it('should short-circuit if error key is present and not falsy in the scoreData', async () => {
@@ -396,13 +396,13 @@ describe('Pipeline Tests', () => {
 
       commentScoreRequests.forEach((request) => {
         if (request.id === commentScoreRequest1.id) {
-          assert.isOk(request.get('doneAt'));
+          assert.isOk(request.doneAt);
         } else {
-          assert.isNull(request.get('doneAt'));
+          assert.isNull(request.doneAt);
         }
       });
 
-      assert.isFalse((await commentScoreRequests[0].getComment())!.get('isScored'));
+      assert.isFalse((await commentScoreRequests[0].getComment())!.isScored);
     });
   });
 
@@ -432,15 +432,15 @@ describe('Pipeline Tests', () => {
       const updatedArticle = (await Article.findById(article.id))!;
       const updatedComment = (await Comment.findById(comment.id))!;
 
-      assert.isTrue(updatedComment.get('isAutoResolved'), 'comment isAutoResolved');
-      assert.equal(updatedComment.get('unresolvedFlagsCount'), 0, 'comment unresolvedFlagsCount');
+      assert.isTrue(updatedComment.isAutoResolved, 'comment isAutoResolved');
+      assert.equal(updatedComment.unresolvedFlagsCount, 0, 'comment unresolvedFlagsCount');
 
-      assert.equal(updatedCategory.get('moderatedCount'), 1, 'category moderatedCount');
-      assert.equal(updatedCategory.get('rejectedCount'), 1, 'category rejectedCount');
+      assert.equal(updatedCategory.moderatedCount, 1, 'category moderatedCount');
+      assert.equal(updatedCategory.rejectedCount, 1, 'category rejectedCount');
 
-      assert.equal(updatedArticle.get('moderatedCount'), 1, 'article moderatedCount');
-      assert.equal(updatedArticle.get('rejectedCount'), 1, 'article rejectedCount');
-      assert.isNull(updatedArticle.get('lastModeratedAt')); // last moderated doesn't get updated by machine ops
+      assert.equal(updatedArticle.moderatedCount, 1, 'article moderatedCount');
+      assert.equal(updatedArticle.rejectedCount, 1, 'article rejectedCount');
+      assert.isNull(updatedArticle.lastModeratedAt); // last moderated doesn't get updated by machine ops
     });
 
     it('should record the Reject decision from a rule', async () => {
@@ -470,9 +470,9 @@ describe('Pipeline Tests', () => {
         },
       }))!;
 
-      assert.equal(decision.get('status'), MODERATION_ACTION_REJECT);
-      assert.equal(decision.get('source'), 'Rule');
-      assert.equal(decision.get('moderationRuleId'), rule.id);
+      assert.equal(decision.status, MODERATION_ACTION_REJECT);
+      assert.equal(decision.source, 'Rule');
+      assert.equal(decision.moderationRuleId, rule.id);
     });
   });
 
@@ -503,7 +503,7 @@ describe('Pipeline Tests', () => {
       const tags = await findOrCreateTagsByKey(Object.keys(scoreData));
 
       const tagsByKey = groupBy(tags, (tag: ITagInstance) => {
-        return tag.get('key');
+        return tag.key;
       });
 
       const [comment, serviceUser] = await Promise.all([
@@ -571,7 +571,7 @@ describe('Pipeline Tests', () => {
       const tags = await findOrCreateTagsByKey(Object.keys(summarScoreData));
 
       const tagsByKey = groupBy(tags, (tag: ITagInstance) => {
-        return tag.get('key');
+        return tag.key;
       });
 
       const comment = await createComment();
@@ -604,8 +604,8 @@ describe('Pipeline Tests', () => {
       assert.lengthOf(results, 1);
 
       const tag = results[0];
-      assert.equal(tag.get('key'), keys[0]);
-      assert.equal(tag.get('label'), 'Attack On Author');
+      assert.equal(tag.key, keys[0]);
+      assert.equal(tag.label, 'Attack On Author');
 
       const instance = (await Tag.findOne({
         where: {
@@ -614,8 +614,8 @@ describe('Pipeline Tests', () => {
       }))!;
 
       assert.equal(tag.id, instance.id);
-      assert.equal(tag.get('key'), instance.get('key'));
-      assert.equal(tag.get('label'), instance.get('label'));
+      assert.equal(tag.key, instance.key);
+      assert.equal(tag.label, instance.label);
     });
 
     it('should find existing tags and resolve their data', async () => {
@@ -632,8 +632,8 @@ describe('Pipeline Tests', () => {
 
       const tag = results[0];
       assert.equal(tag.id, dbTag.id);
-      assert.equal(tag.get('key'), key);
-      assert.equal(tag.get('label'), 'Spam');
+      assert.equal(tag.key, key);
+      assert.equal(tag.label, 'Spam');
     });
 
     it('should resolve a mix of existing and new tags', async () => {
@@ -649,12 +649,12 @@ describe('Pipeline Tests', () => {
       assert.lengthOf(results, keys.length);
 
       results.forEach((tag) => {
-        if (tag.get('key') === 'INCOHERENT') {
+        if (tag.key === 'INCOHERENT') {
           assert.equal(tag.id, dbTag.id);
         } else {
           assert.isNumber(tag.id);
-          assert.equal(tag.get('key'), 'OFF_TOPIC');
-          assert.equal(tag.get('label'), 'Off Topic');
+          assert.equal(tag.key, 'OFF_TOPIC');
+          assert.equal(tag.label, 'Off Topic');
         }
       });
     });
@@ -676,11 +676,11 @@ describe('Pipeline Tests', () => {
 
       const firstDecision = foundDecisions[0];
 
-      assert.equal(firstDecision.get('commentId'), comment.id);
-      assert.equal(firstDecision.get('source'), 'User');
-      assert.equal(firstDecision.get('userId'), user.id);
-      assert.equal(firstDecision.get('status'), MODERATION_ACTION_ACCEPT);
-      assert.isTrue(firstDecision.get('isCurrentDecision'));
+      assert.equal(firstDecision.commentId, comment.id);
+      assert.equal(firstDecision.source, 'User');
+      assert.equal(firstDecision.userId, user.id);
+      assert.equal(firstDecision.status, MODERATION_ACTION_ACCEPT);
+      assert.isTrue(firstDecision.isCurrentDecision);
     });
 
     it('should clear old decisions', async () => {
@@ -717,11 +717,11 @@ describe('Pipeline Tests', () => {
 
       const firstDecision = currentDecisions[0];
 
-      assert.equal(firstDecision.get('commentId'), comment.id);
-      assert.equal(firstDecision.get('source'), 'Rule');
-      assert.equal(firstDecision.get('moderationRuleId'), rule.id);
-      assert.equal(firstDecision.get('status'), MODERATION_ACTION_REJECT);
-      assert.isTrue(firstDecision.get('isCurrentDecision'));
+      assert.equal(firstDecision.commentId, comment.id);
+      assert.equal(firstDecision.source, 'Rule');
+      assert.equal(firstDecision.moderationRuleId, rule.id);
+      assert.equal(firstDecision.status, MODERATION_ACTION_REJECT);
+      assert.isTrue(firstDecision.isCurrentDecision);
     });
   });
 });

--- a/packages/backend-api/src/test/pipeline/rules.spec.ts
+++ b/packages/backend-api/src/test/pipeline/rules.spec.ts
@@ -57,10 +57,10 @@ describe('Pipeline Rules Tests', () => {
   describe('compileScores', () => {
     it('should return an object of scores keyed by tag id', () => {
       const tag1 = Tag.build(getTagData());
-      tag1.set('id', 1);
+      tag1.id = 1;
 
       const tag2 = Tag.build(getTagData());
-      tag2.set('id', 2);
+      tag2.id =2;
 
       const score1 = CommentSummaryScore.build(getCommentSummaryScoreData({tagId: 1, score: 0.57}));
       const score2 = CommentSummaryScore.build(getCommentSummaryScoreData({tagId: 2, score: 0.75}));
@@ -76,10 +76,10 @@ describe('Pipeline Rules Tests', () => {
 
     it('should get the max scores with the same tag', () => {
       const tag1 = Tag.build(getTagData());
-      tag1.set('id', 1);
+      tag1.id = 1;
 
       const tag2 = Tag.build(getTagData());
-      tag2.set('id', 2);
+      tag2.id = 2 ;
 
       const score1 = CommentSummaryScore.build(getCommentSummaryScoreData({tagId: 1, score: 0.5}));
       const score2 = CommentSummaryScore.build(getCommentSummaryScoreData({tagId: 2, score: 0.6}));
@@ -130,16 +130,16 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isTrue(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isTrue(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         // Rules shouldn't updated lastModeratedAt
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -153,7 +153,7 @@ describe('Pipeline Rules Tests', () => {
         CommentSummaryScore.build({
           commentId: comment.id,
           tagId: summaryTag.id,
-          score: comment.get('maxSummaryScore'),
+          score: comment.maxSummaryScore,
         }),
       ];
 
@@ -171,15 +171,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isTrue(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isTrue(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -222,15 +222,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isTrue(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isTrue(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -270,15 +270,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isTrue(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isTrue(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isTrue(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isTrue(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -318,15 +318,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isTrue(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isNull(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isTrue(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -353,15 +353,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isFalse(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isFalse(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -401,15 +401,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isFalse(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isFalse(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -436,15 +436,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isTrue(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isNull(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isTrue(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -493,15 +493,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isTrue(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isNull(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isTrue(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -554,15 +554,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isTrue(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isNull(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isTrue(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -602,15 +602,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isTrue(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isTrue(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isTrue(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isTrue(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -656,15 +656,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'), 'isAccepted');
-        assert.isTrue(updated.get('isAutoResolved'), 'isAutoResolved');
-        assert.isFalse(updated.get('isHighlighted'), 'isHighlighted');
-        assert.isTrue(updated.get('isDeferred'), 'isDeferred');
-        assert.isTrue(updated.get('isModerated'), 'isModerated');
-        assert.isFalse(updated.get('isScored'), 'isScored');
+        assert.isNull(updated.isAccepted, 'isAccepted');
+        assert.isTrue(updated.isAutoResolved, 'isAutoResolved');
+        assert.isFalse(updated.isHighlighted, 'isHighlighted');
+        assert.isTrue(updated.isDeferred, 'isDeferred');
+        assert.isTrue(updated.isModerated, 'isModerated');
+        assert.isFalse(updated.isScored, 'isScored');
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -719,15 +719,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'), 'isAccepted');
-        assert.isTrue(updated.get('isAutoResolved'), 'isAutoResolved');
-        assert.isFalse(updated.get('isHighlighted'), 'isHighlighted');
-        assert.isTrue(updated.get('isDeferred'), 'isDeferred');
-        assert.isTrue(updated.get('isModerated'), 'isModerated');
-        assert.isFalse(updated.get('isScored'), 'isScored');
+        assert.isNull(updated.isAccepted, 'isAccepted');
+        assert.isTrue(updated.isAutoResolved, 'isAutoResolved');
+        assert.isFalse(updated.isHighlighted, 'isHighlighted');
+        assert.isTrue(updated.isDeferred, 'isDeferred');
+        assert.isTrue(updated.isModerated, 'isModerated');
+        assert.isFalse(updated.isScored, 'isScored');
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -767,15 +767,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'), 'isAccepted');
-        assert.isFalse(updated.get('isAutoResolved'), 'isAutoResolved');
-        assert.isFalse(updated.get('isHighlighted'), 'isHighlighted');
-        assert.isFalse(updated.get('isDeferred'), 'isDeferred');
-        assert.isFalse(updated.get('isModerated'), 'isModerated');
-        assert.isFalse(updated.get('isScored'), 'isScored');
+        assert.isNull(updated.isAccepted, 'isAccepted');
+        assert.isFalse(updated.isAutoResolved, 'isAutoResolved');
+        assert.isFalse(updated.isHighlighted, 'isHighlighted');
+        assert.isFalse(updated.isDeferred, 'isDeferred');
+        assert.isFalse(updated.isModerated, 'isModerated');
+        assert.isFalse(updated.isScored, 'isScored');
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
   });
@@ -791,15 +791,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'));
-        assert.isFalse(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isFalse(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isNull(updated.isAccepted);
+        assert.isFalse(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isFalse(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -823,12 +823,12 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isNull(updated.get('isAccepted'));
-        assert.isFalse(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isFalse(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isNull(updated.isAccepted);
+        assert.isFalse(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isFalse(updated.isModerated);
+        assert.isFalse(updated.isScored);
       }
     });
 
@@ -877,15 +877,15 @@ describe('Pipeline Rules Tests', () => {
       assert.isNotNull(updated);
 
       if (updated) {
-        assert.isTrue(updated.get('isAccepted'));
-        assert.isTrue(updated.get('isAutoResolved'));
-        assert.isFalse(updated.get('isHighlighted'));
-        assert.isFalse(updated.get('isDeferred'));
-        assert.isTrue(updated.get('isModerated'));
-        assert.isFalse(updated.get('isScored'));
+        assert.isTrue(updated.isAccepted);
+        assert.isTrue(updated.isAutoResolved);
+        assert.isFalse(updated.isHighlighted);
+        assert.isFalse(updated.isDeferred);
+        assert.isTrue(updated.isModerated);
+        assert.isFalse(updated.isScored);
 
         const updatedArticle = await updated.getArticle();
-        assert.isNull(updatedArticle.get('lastModeratedAt'));
+        assert.isNull(updatedArticle.lastModeratedAt);
       }
     });
 
@@ -933,7 +933,7 @@ describe('Pipeline Rules Tests', () => {
       const updated = await Comment.findById(comment.id);
       assert.isNotNull(updated);
       if (updated) {
-        assert.isNull(updated.get('isAccepted'));
+        assert.isNull(updated.isAccepted);
       }
     });
   });

--- a/packages/backend-api/src/test/unit/util/queryComments.spec.ts
+++ b/packages/backend-api/src/test/unit/util/queryComments.spec.ts
@@ -87,16 +87,16 @@ describe('queryComments Functions', () => {
 
       expect(Object.keys(results)).to.be.lengthOf(2);
       expect(results[comment1.id]).to.deep.equal({
-        commentId: comment1Top.get('commentId'),
-        score: comment1Top.get('score'),
-        start: comment1Top.get('annotationStart'),
-        end: comment1Top.get('annotationEnd'),
+        commentId: comment1Top.commentId,
+        score: comment1Top.score,
+        start: comment1Top.annotationStart,
+        end: comment1Top.annotationEnd,
       });
       expect(results[comment2.id]).to.deep.equal({
-        commentId: comment2Top.get('commentId'),
-        score: comment2Top.get('score'),
-        start: comment2Top.get('annotationStart'),
-        end: comment2Top.get('annotationEnd'),
+        commentId: comment2Top.commentId,
+        score: comment2Top.score,
+        start: comment2Top.annotationStart,
+        end: comment2Top.annotationEnd,
       });
     });
 
@@ -107,10 +107,10 @@ describe('queryComments Functions', () => {
       expect(Object.keys(results)).to.be.lengthOf(1);
 
       expect(results[comment2.id]).to.deep.equal({
-        commentId: comment2Top.get('commentId'),
-        score: comment2Top.get('score'),
-        start: comment2Top.get('annotationStart'),
-        end: comment2Top.get('annotationEnd'),
+        commentId: comment2Top.commentId,
+        score: comment2Top.score,
+        start: comment2Top.annotationStart,
+        end: comment2Top.annotationEnd,
       });
     });
 
@@ -126,10 +126,10 @@ describe('queryComments Functions', () => {
       expect(Object.keys(results)).to.be.lengthOf(1);
 
       expect(results[comment1.id]).to.deep.equal({
-        commentId: comment1Top.get('commentId'),
-        score: comment1Top.get('score'),
-        start: comment1Top.get('annotationStart'),
-        end: comment1Top.get('annotationEnd'),
+        commentId: comment1Top.commentId,
+        score: comment1Top.score,
+        start: comment1Top.annotationStart,
+        end: comment1Top.annotationEnd,
       });
     });
 
@@ -145,10 +145,10 @@ describe('queryComments Functions', () => {
       expect(Object.keys(results)).to.be.lengthOf(1);
 
       expect(results[comment1.id]).to.deep.equal({
-        commentId: comment1Top.get('commentId'),
-        score: comment1Top.get('score'),
-        start: comment1Top.get('annotationStart'),
-        end: comment1Top.get('annotationEnd'),
+        commentId: comment1Top.commentId,
+        score: comment1Top.score,
+        start: comment1Top.annotationStart,
+        end: comment1Top.annotationEnd,
       });
     });
 
@@ -170,10 +170,10 @@ describe('queryComments Functions', () => {
       expect(Object.keys(results)).to.be.lengthOf(1);
 
       expect(results[comment1.id]).to.deep.equal({
-        commentId: comment1Top.get('commentId'),
-        score: comment1Top.get('score'),
-        start: comment1Top.get('annotationStart'),
-        end: comment1Top.get('annotationEnd'),
+        commentId: comment1Top.commentId,
+        score: comment1Top.score,
+        start: comment1Top.annotationStart,
+        end: comment1Top.annotationEnd,
       });
     });
   });


### PR DESCRIPTION
Get the sequelize types closer to what they should be, e.g., as described here:
https://michalzalecki.com/using-sequelize-with-typescript/

Once fixed types are in place, we can replace getters and setters with directly updating the instance attributes.  This has much better type checking.

Fix up any type errors the above changes expose.  