### PR TITLE
Revert "build(deps): bump sequelize from 3.35.1 to 5.21.2 in /packages/backend-api"

### DIFF
--- a/packages/backend-api/package.json
+++ b/packages/backend-api/package.json
@@ -62,7 +62,7 @@
     "randomstring": "1.1.5",
     "redis": "2.7.1",
     "request": "2.87.0",
-    "sequelize": "5.21.2",
+    "sequelize": "3.35.1",
     "sequelize-cli": "2.8.0",
     "striptags": "3.1.1",
     "ts-node-dev": "1.0.0-pre.32",


### PR DESCRIPTION
Reverts conversationai/conversationai-moderator#77

Code won't build with this version of sequelize.  (Fixing is a work in progress.)