### PR TITLE
Rufus hamade fix store types 1

### DIFF
--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -699,8 +699,8 @@ export async function resetCommentScoreRequest(commentId: string, commentScoreId
 }
 
 export async function listAuthorCounts(
-  authorSourceIds: Array<string | number>,
-): Promise<Map<string | number, IAuthorCountsModel>> {
+  authorSourceIds: Array<string>,
+): Promise<Map<string, IAuthorCountsModel>> {
   const response: any = await axios.post(
     serviceURL('authorCounts'),
     { data: authorSourceIds },

--- a/packages/frontend-web/src/app/scenes/Comments/components/ThreadedCommentDetail/store.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/components/ThreadedCommentDetail/store.ts
@@ -23,12 +23,11 @@ import {
 import { getModel } from '../../../../platform/dataService';
 import { IAppDispatch, IAppStateRecord } from '../../../../stores';
 import {
+  ISingleRecordState,
   makeSingleRecordReducer,
 } from '../../../../util';
 
-const DATA_PREFIX = ['scenes', 'commentsIndex', 'threadedCommentDetail', 'comment'];
-const COMMENT_DATA = [...DATA_PREFIX, 'item'];
-const LOADING_STATUS = [...DATA_PREFIX, 'isFetching'];
+const COMMENT_DATA = ['scenes', 'commentsIndex', 'threadedCommentDetail', 'comment'];
 
 const loadCommentStart =
   createAction('threaded-comment-detail/LOAD_COMMENT_START');
@@ -58,10 +57,12 @@ export const reducer: any = combineReducers({
   comment: commentReducer,
 });
 
-export function getComment(state: IAppStateRecord): ICommentModel {
-  return state.getIn(COMMENT_DATA);
+export function getComment(state: IAppStateRecord) {
+  const commentRecord = state.getIn(COMMENT_DATA) as ISingleRecordState<ICommentModel>;
+  return commentRecord && commentRecord.item;
 }
 
-export function getIsLoading(state: IAppStateRecord): boolean {
-  return state.getIn(LOADING_STATUS);
+export function getIsLoading(state: IAppStateRecord) {
+  const commentRecord = state.getIn(COMMENT_DATA) as ISingleRecordState<ICommentModel>;
+  return commentRecord && commentRecord.isFetching;
 }

--- a/packages/frontend-web/src/app/scenes/Search/store/searchResults.ts
+++ b/packages/frontend-web/src/app/scenes/Search/store/searchResults.ts
@@ -16,10 +16,8 @@ limitations under the License.
 
 import { List } from 'immutable';
 import { Action, createAction, handleActions } from 'redux-actions';
-import { makeTypedFactory, TypedRecord} from 'typed-immutable-record';
 import { IAppStateRecord } from '../../../stores';
 import { DATA_PREFIX } from './reduxPrefix';
-const ALL_COMMENT_IDS_DATA = [...DATA_PREFIX, 'allCommentIds'];
 
 export type ILoadAllCommentIdsCompletePayload = List<string>;
 export const loadAllCommentIdsComplete: (payload: ILoadAllCommentIdsCompletePayload) => Action<ILoadAllCommentIdsCompletePayload> =
@@ -31,31 +29,30 @@ export const resetCommentIds: () => Action<void> = createAction(
   'search/RESET_ALL_COMMENT_IDS',
 );
 
-export interface IAllCommentIDsState {
+export type IAllCommentIDsState = Readonly<{
   ids: List<string>;
-}
+}>;
 
-export interface IAllCommentIDsStateRecord extends TypedRecord<IAllCommentIDsStateRecord>, IAllCommentIDsState {}
-
-const StateFactory = makeTypedFactory<IAllCommentIDsState, IAllCommentIDsStateRecord>({
+const initialState = {
   ids: List<string>(),
-});
+};
 
 export const allCommentIdsReducer = handleActions<
-  IAllCommentIDsStateRecord,
+  IAllCommentIDsState,
   void | // resetCommentIds
   ILoadAllCommentIdsCompletePayload // loadAllCommentIdsComplete
 >({
-    [resetCommentIds.toString()]: () => StateFactory(),
+    [resetCommentIds.toString()]: () => initialState,
 
-    [loadAllCommentIdsComplete.toString()]: (state, { payload }: Action<ILoadAllCommentIdsCompletePayload>) => (
-      state.set('ids', payload)
+    [loadAllCommentIdsComplete.toString()]: (_state, { payload }: Action<ILoadAllCommentIdsCompletePayload>) => (
+      {ids: payload}
     ),
   },
 
-  StateFactory(),
+  initialState,
 );
 
-export function getAllCommentIds(state: IAppStateRecord): List<number> {
-  return state.getIn([...ALL_COMMENT_IDS_DATA, 'ids']);
+export function getAllCommentIds(state: IAppStateRecord) {
+  const commentIds = state.getIn([...DATA_PREFIX, 'allCommentIds']) as IAllCommentIDsState;
+  return commentIds.ids;
 }

--- a/packages/frontend-web/src/app/util/makeRecordListReducer/__spec__/makeRecordListReducer.spec.ts
+++ b/packages/frontend-web/src/app/util/makeRecordListReducer/__spec__/makeRecordListReducer.spec.ts
@@ -94,65 +94,37 @@ const testData = Map({
 describe('makeRecordListReducer reducer', () => {
   it('should detect an event has started', () => {
     const testState = reducer(testMakeRecordListReducer.initialState, testStartEvent(''));
-    expect(
-      testState.getIn(['isFetching']),
-    ).to.be.true;
+    expect(testState.isFetching).to.be.true;
   });
 
   it('should detect an event has ended', () => {
     let testState = reducer(testMakeRecordListReducer.initialState, testStartEvent(''));
-    expect(
-      testState.getIn(['isFetching']),
-    ).to.be.true;
+    expect(testState.isFetching).to.be.true;
 
     testState = reducer(testState, testEndEvent(testData));
-    expect(
-      testState.getIn(['isFetching']),
-    ).to.be.false;
-
-    expect(
-      testState.getIn(['hasData']),
-    ).to.be.true;
-
-    expect(
-      testState.getIn(['items'], 0).id,
-    ).to.equal(
+    expect(testState.isFetching).to.be.false;
+    expect(testState.hasData).to.be.true;
+    expect(testState.items.get(0).id).to.equal(
       testData.getIn(['data'], 0).id,
     );
   });
 
   it('should add a record', () => {
     const testState = reducer(testMakeRecordListReducer.initialState, testMakeRecordListReducer.addRecord(testData));
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      1,
-    );
+    expect(testState.items.size).to.equal(1);
   });
 
   it('should add a second record', () => {
     let testState = reducer(testMakeRecordListReducer.initialState, testMakeRecordListReducer.addRecord(testData));
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      1,
-    );
+    expect(testState.items.size).to.equal(1);
 
     testState = reducer(testState, testMakeRecordListReducer.addRecord(testData));
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      2,
-    );
+    expect(testState.items.size).to.equal(2);
   });
 
   it('should update a record', () => {
     let testState = reducer(testMakeRecordListReducer.initialState, testMakeRecordListReducer.addRecord(testData));
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      1,
-    );
+    expect(testState.items.size).to.equal(1);
 
     const testRecord = Map({
       id: 3,
@@ -187,7 +159,7 @@ describe('makeRecordListReducer reducer', () => {
 
     let checkedRecord = null;
 
-    testState.getIn(['items']).forEach((item: any) => {
+    testState.items.forEach((item: any) => {
       if (item.get('id') === 3) {
         checkedRecord = item;
       }
@@ -200,11 +172,7 @@ describe('makeRecordListReducer reducer', () => {
 
   it('should remove a record', () => {
     let testState = reducer(testMakeRecordListReducer.initialState, testMakeRecordListReducer.addRecord(testData));
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      1,
-    );
+    expect(testState.items.size).to.equal(1);
 
     const testRecord = Map({
       id: 3,
@@ -236,29 +204,15 @@ describe('makeRecordListReducer reducer', () => {
     });
 
     testState = reducer(testState, testMakeRecordListReducer.addRecord(testRecord));
-
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      2,
-    );
+    expect(testState.items.size).to.equal(2);
 
     testState = reducer(testState, testMakeRecordListReducer.removeRecord(testRecord));
-
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      1,
-    );
+    expect(testState.items.size).to.equal(1);
   });
 
   it('should remove a second record', () => {
     let testState = reducer(testMakeRecordListReducer.initialState, testMakeRecordListReducer.addRecord(testData));
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      1,
-    );
+    expect(testState.items.size).to.equal(1);
 
     const testRecordOne = Map({
       id: 3,
@@ -291,12 +245,7 @@ describe('makeRecordListReducer reducer', () => {
     });
 
     testState = reducer(testState, testMakeRecordListReducer.addRecord(testRecordOne));
-
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      2,
-    );
+    expect(testState.items.size).to.equal(2);
 
     const testRecordTwo = Map({
       id: 4,
@@ -329,23 +278,15 @@ describe('makeRecordListReducer reducer', () => {
 
     testState = reducer(testState, testMakeRecordListReducer.addRecord(testRecordTwo));
 
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      3,
-    );
+    expect(testState.items.size).to.equal(3);
 
     testState = reducer(testState, testMakeRecordListReducer.removeRecord(testRecordOne));
 
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      2,
-    );
+    expect(testState.items.size).to.equal(2);
 
     let expectedItem = null;
 
-    testState.getIn(['items']).forEach((item: any) => {
+    testState.items.forEach((item: any) => {
       if (item.get('id') === 4) {
         expectedItem = item;
       }
@@ -356,11 +297,6 @@ describe('makeRecordListReducer reducer', () => {
     ).to.be.true;
 
     testState = reducer(testState, testMakeRecordListReducer.removeRecord(testRecordTwo));
-
-    expect(
-      testState.getIn(['items']).size,
-    ).to.equal(
-      1,
-    );
+    expect(testState.items.size).to.equal(1);
   });
 });


### PR DESCRIPTION
We have got the types quite wrong in the frontend store.  This is one of the things preventing us from updating redux to the latest version as the typing becomes much fussier in that version.

This series of changes aims to improve this situation in two ways:
 - Replace TypedRecord instances with standard typescript readonly objects, which have much better type checking.  
 - Fix the type errors that the above change exposes  
