### PR TITLE
Sequelize update groundwork

### DIFF
--- a/packages/backend-api/package.json
+++ b/packages/backend-api/package.json
@@ -7,7 +7,7 @@
     "build": "npm run compile",
     "compile": "rm -rf dist && ../../node_modules/.bin/tsc --sourceMap --outDir dist --declaration",
     "test": "npm run mocha",
-    "mocha": "WORKER_RUN_IMMEDIATELY=true ../../node_modules/.bin/ts-mocha 'src/test/**/*.spec.ts' --timeout 200000",
+    "mocha": "WORKER_RUN_IMMEDIATELY=true ts-mocha 'src/test/**/*.spec.ts' --timeout 200000",
     "lint": "find src -name '*.ts' | xargs ../../node_modules/.bin/tslint -c ../../tslint.json"
   },
   "license": "Apache-2.0",

--- a/packages/backend-api/src/api/publisher/index.ts
+++ b/packages/backend-api/src/api/publisher/index.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import * as express from 'express';
 import * as Joi from 'joi';
-import { Op } from 'sequelize';
+import { fn, Op } from 'sequelize';
 
 import { logger } from '../../logger';
 import {
@@ -29,7 +29,6 @@ import {
   IProcessTagAdditionData,
   IProcessTagData,
 } from '../../processing';
-import { sequelize } from '../../sequelize';
 import { REPLY_SUCCESS } from '../constants';
 import * as JSONAPI from '../jsonapi';
 import { list } from '../util/SequelizeHandler';
@@ -214,7 +213,7 @@ export function createPublisherService(): express.Router {
         const decisionIds = body.data.map((s: any) => parseInt(s, 10));
 
         await Decision.update({
-          sentBackToPublisher: sequelize.fn('now'),
+          sentBackToPublisher: fn('now'),
         }, {
           where: {
             id: {

--- a/packages/backend-api/src/api/services/histogramScores/util.ts
+++ b/packages/backend-api/src/api/services/histogramScores/util.ts
@@ -16,10 +16,12 @@ limitations under the License.
 
 const { Canvas } = require('canvas');
 
+import { QueryTypes } from 'sequelize';
+
 import { DotChartRenderer, groupByDateColumns, groupByScoreColumns } from '@conversationai/moderator-frontend-web';
 
 import { Article, Category, Tag } from '../../../models';
-import { sequelize as sequelizeInstance } from '../../../sequelize';
+import { sequelize } from '../../../sequelize';
 import * as JSONAPI from '../../jsonapi';
 import { sort } from '../../util/SequelizeHandler';
 
@@ -71,7 +73,7 @@ export async function getHistogramScoresForAllCategories(tagId: number): Promise
   const tag = await Tag.findByPk(tagId);
   if (!tag) { throw new JSONAPI.NotFoundError(`Could not find tag ${tagId}`); }
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comment_summary_scores.score AS score, comment_summary_scores.commentId ' +
     'FROM comments ' +
     'JOIN comment_summary_scores ON comment_summary_scores.commentId = comments.id ' +
@@ -83,7 +85,7 @@ export async function getHistogramScoresForAllCategories(tagId: number): Promise
       replacements: {
         tagId,
       },
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -92,12 +94,12 @@ export async function getHistogramScoresForAllCategories(tagId: number): Promise
  * Get the max score for each comment across all categories.
  */
 export async function getHistogramScoresForAllCategoriesByDate(): Promise<Array<ICommentDated>> {
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comments.id as commentId, comments.sourceCreatedAt as date ' +
     'FROM comments ' +
     'WHERE comments.isModerated = false ',
     {
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -117,7 +119,7 @@ export async function getHistogramScoresForCategory(categoryId: number | 'all', 
   const tag = await Tag.findByPk(tagId);
   if (!tag) { throw new JSONAPI.NotFoundError(`Could not find tag ${tagId}`); }
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comment_summary_scores.score AS score, comment_summary_scores.commentId ' +
     'FROM comments ' +
     'JOIN articles ON articles.id = comments.articleId ' +
@@ -132,7 +134,7 @@ export async function getHistogramScoresForCategory(categoryId: number | 'all', 
         categoryId,
         tagId,
       },
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -149,7 +151,7 @@ export async function getHistogramScoresForCategoryByDate(categoryId: number | '
   const category = await Category.findByPk(categoryId);
   if (!category) { throw new JSONAPI.NotFoundError(`Could not find category ${categoryId}`); }
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comments.id as commentId, comments.sourceCreatedAt as date ' +
     'FROM comments ' +
     'JOIN articles ON articles.id = comments.articleId ' +
@@ -159,7 +161,7 @@ export async function getHistogramScoresForCategoryByDate(categoryId: number | '
       replacements: {
         categoryId,
       },
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -174,7 +176,7 @@ export async function getHistogramScoresForArticle(articleId: number, tagId: num
   const tag = await Tag.findByPk(tagId);
   if (!tag) { throw new JSONAPI.NotFoundError(`Could not find tag ${tagId}`); }
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comment_summary_scores.score AS score, comment_summary_scores.commentId ' +
     'FROM comments ' +
     'JOIN comment_summary_scores ON comment_summary_scores.commentId = comments.id ' +
@@ -188,7 +190,7 @@ export async function getHistogramScoresForArticle(articleId: number, tagId: num
         articleId,
         tagId,
       },
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -200,7 +202,7 @@ export async function getHistogramScoresForArticleByDate(articleId: number): Pro
   const article = await Article.findByPk(articleId);
   if (!article) { throw new JSONAPI.NotFoundError(`Could not find article ${articleId}`); }
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comments.id as commentId, comments.sourceCreatedAt as date ' +
     'FROM comments ' +
     'WHERE comments.articleId = :articleId ' +
@@ -209,7 +211,7 @@ export async function getHistogramScoresForArticleByDate(articleId: number): Pro
       replacements: {
         articleId,
       },
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -221,7 +223,7 @@ export async function getMaxSummaryScoreForArticle(articleId: number): Promise<A
   const article = await Article.findByPk(articleId);
   if (!article) { throw new JSONAPI.NotFoundError(`Could not find article ${articleId}`); }
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comments.id as commentId, comments.maxSummaryScore as score ' +
     'FROM comments ' +
     'WHERE comments.articleId = :articleId ' +
@@ -232,7 +234,7 @@ export async function getMaxSummaryScoreForArticle(articleId: number): Promise<A
       replacements: {
         articleId,
       },
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -242,7 +244,7 @@ export async function getMaxSummaryScoreForArticle(articleId: number): Promise<A
  */
 export async function getMaxHistogramScoresForAllCategories(): Promise<Array<ICommentScored>> {
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comments.id as commentId, comments.maxSummaryScore as score ' +
     'FROM comments ' +
     'WHERE comments.isScored = true ' +
@@ -250,7 +252,7 @@ export async function getMaxHistogramScoresForAllCategories(): Promise<Array<ICo
     'AND comments.maxSummaryScore IS NOT NULL ' +
     'ORDER BY score DESC',
     {
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }
@@ -267,7 +269,7 @@ export async function getMaxSummaryScoreForCategory(categoryId: number | 'all'):
   const category = await Category.findByPk(categoryId);
   if (!category) { throw new JSONAPI.NotFoundError(`Could not find category ${categoryId}`); }
 
-  return sequelizeInstance.query(
+  return sequelize.query(
     'SELECT comments.id as commentId, comments.maxSummaryScore as score ' +
     'FROM comments ' +
     'JOIN articles ON articles.id = comments.articleId ' +
@@ -280,7 +282,7 @@ export async function getMaxSummaryScoreForCategory(categoryId: number | 'all'):
       replacements: {
         categoryId,
       },
-      type: sequelizeInstance.QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
     },
   );
 }

--- a/packages/backend-api/src/api/services/topScores.ts
+++ b/packages/backend-api/src/api/services/topScores.ts
@@ -17,9 +17,10 @@ limitations under the License.
 import * as express from 'express';
 import * as Joi from 'joi';
 import { mapValues } from 'lodash';
+import { QueryTypes } from 'sequelize';
 
 import { Tag } from '../../models';
-import { sequelize as sequelizeInstance } from '../../sequelize';
+import { sequelize } from '../../sequelize';
 import * as JSONAPI from '../jsonapi';
 import { filterTopScoresByTaggingSensitivity } from '../util/queryComments';
 import { validateAndSendResponse, validateRequest } from '../util/validation';
@@ -80,7 +81,7 @@ export function createTopScoresService(): express.Router {
           return;
         }
 
-        const results = await sequelizeInstance.query(
+        const results = await sequelize.query(
           'SELECT comment_scores.score AS score, comment_scores.annotationStart AS start, comment_scores.annotationEnd AS end, comments.id as commentId ' +
           'FROM comments ' +
           'JOIN comment_top_scores ON comment_top_scores.commentId = comments.id ' +
@@ -92,7 +93,7 @@ export function createTopScoresService(): express.Router {
               tagId,
               commentIds,
             },
-            type: sequelizeInstance.QueryTypes.SELECT,
+            type: QueryTypes.SELECT,
           },
         );
 
@@ -145,7 +146,7 @@ export function createTopScoresService(): express.Router {
 
         const commentIds = summaryScores.map((score) => score.commentId);
 
-        const results = await sequelizeInstance.query(
+        const results = await sequelize.query(
           'SELECT comment_scores.score AS score, comment_scores.annotationStart AS start, ' +
           'comment_scores.annotationEnd AS end, comments.id as commentId ' +
           'FROM comments ' +
@@ -157,7 +158,7 @@ export function createTopScoresService(): express.Router {
             replacements: {
               commentIds,
             },
-            type: sequelizeInstance.QueryTypes.SELECT,
+            type: QueryTypes.SELECT,
           },
         );
 

--- a/packages/backend-api/src/commands/comments/rebuild_reply_relations.ts
+++ b/packages/backend-api/src/commands/comments/rebuild_reply_relations.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import * as Bluebird from 'bluebird';
+import { QueryTypes } from 'sequelize';
 import * as yargs from 'yargs';
 
 import { logger } from '../../logger';
@@ -37,7 +38,7 @@ export async function handler() {
       'FROM comments as c ' +
       'LEFT JOIN comments as c2 ON c.sourceId = c2.replyToSourceId ' +
       'WHERE c2.id IS NOT NULL;',
-      { type: sequelize.QueryTypes.SELECT },
+      { type: QueryTypes.SELECT },
     );
 
     logger.info('Found ' + results.length + ' comments with replies');
@@ -46,7 +47,7 @@ export async function handler() {
       const existing = await sequelize.query(
         'SELECT commentId, replyId FROM comment_replies ' +
         'WHERE commentId = ' + row.commentId + ' AND replyId = ' + row.replyId + ';',
-        { type: sequelize.QueryTypes.SELECT },
+        { type: QueryTypes.SELECT },
       );
 
       if (existing && existing.length > 0) { return Bluebird.resolve(); }

--- a/packages/backend-api/src/domain/articles/countDenormalization.ts
+++ b/packages/backend-api/src/domain/articles/countDenormalization.ts
@@ -43,7 +43,7 @@ export async function denormalizeCommentCountsForArticle(article: IArticleInstan
   const deferredCount = await Comment.count({ where: { articleId: article.id, isDeferred: true } });
   const flaggedCount = await Comment.count({ where: { articleId: article.id,
       [Op.or]: [{ isModerated: false }, { isAccepted: true }],
-      unresolvedFlagsCount: { [Op.gt]: 0 } } })
+      unresolvedFlagsCount: { [Op.gt]: 0 } } });
   const batchedCount = await Comment.count({ where: { articleId: article.id, isModerated: true, isBatchResolved: true } });
 
   const update: Partial<IArticleAttributes> = {

--- a/packages/backend-api/src/integrations/decisions.ts
+++ b/packages/backend-api/src/integrations/decisions.ts
@@ -22,7 +22,6 @@ import {
   IDecisionInstance,
   IUserInstance,
 } from '../models';
-import { sequelize } from '../sequelize';
 
 export async function getDecisionForComment(
   comment: ICommentInstance,
@@ -54,9 +53,9 @@ export async function foreachPendingDecision(
 }
 
 export async function markDecisionExecuted(decision: IDecisionInstance) {
-  decision.sentBackToPublisher = sequelize.fn('now');
+  decision.sentBackToPublisher = new Date();
   await decision.save();
   const comment = (await decision.getComment())!;
-  comment.sentBackToPublisher = sequelize.fn('now');
+  comment.sentBackToPublisher = new Date();
   await comment.save();
 }

--- a/packages/backend-api/src/models/comment.ts
+++ b/packages/backend-api/src/models/comment.ts
@@ -56,7 +56,7 @@ export interface ICommentAttributes extends IBaseAttributes {
   unresolvedFlagsCount?: number;
   flagsSummary?: IFlagSummary | null;
   sourceCreatedAt: Date | null | Sequelize.fn;
-  sentForScoring?: string | null | Sequelize.fn;
+  sentForScoring?: Date | null | Sequelize.fn;
   sentBackToPublisher?: Date | null | Sequelize.fn;
   extra?: object | null;
   maxSummaryScore?: number | null;

--- a/packages/backend-api/src/models/csrf.ts
+++ b/packages/backend-api/src/models/csrf.ts
@@ -30,6 +30,12 @@ export type ICSRFInstance = Sequelize.Instance<ICSRFAttributes> & ICSRFAttribute
  * CSRF model
  */
 export const CSRF = sequelize.define<ICSRFInstance, ICSRFAttributes>('csrfs', {
+  id: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+
   clientCSRF: {
     type: Sequelize.CHAR(255),
     allowNull: false,

--- a/packages/backend-api/src/models/moderation_rule.ts
+++ b/packages/backend-api/src/models/moderation_rule.ts
@@ -53,6 +53,12 @@ export const ModerationRule = sequelize.define<
   IModerationRuleInstance,
   IModerationRuleAttributes
 >('moderation_rules', {
+  id: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+
   tagId: {
     type: Sequelize.INTEGER.UNSIGNED,
     allowNull: false,

--- a/packages/backend-api/src/models/moderator_assignment.ts
+++ b/packages/backend-api/src/models/moderator_assignment.ts
@@ -35,6 +35,12 @@ export const ModeratorAssignment = sequelize.define<
 >(
   'moderator_assignment',
   {
+    id: {
+      type: Sequelize.INTEGER.UNSIGNED,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+
     userId: {
       type: Sequelize.INTEGER.UNSIGNED,
       allowNull: false,

--- a/packages/backend-api/src/models/preselect.ts
+++ b/packages/backend-api/src/models/preselect.ts
@@ -37,6 +37,27 @@ export const Preselect = sequelize.define<
   IPreselectInstance,
   IPreselectAttributes
 >('preselect', {
+  id: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+
+  tagId: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    allowNull: true,
+  },
+
+  categoryId: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    allowNull: true,
+  },
+
+  createdBy: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    allowNull: true,
+  },
+
   lowerThreshold: {
     type: Sequelize.FLOAT(2).UNSIGNED,
     allowNull: false,

--- a/packages/backend-api/src/models/tagging_sensitivity.ts
+++ b/packages/backend-api/src/models/tagging_sensitivity.ts
@@ -38,6 +38,27 @@ export const TaggingSensitivity = sequelize.define<
   ITaggingSensitivityInstance,
   ITaggingSensitivityAttributes
 >('tagging_sensitivity', {
+  id: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+
+  tagId: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    allowNull: true,
+  },
+
+  categoryId: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    allowNull: true,
+  },
+
+  createdBy: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    allowNull: true,
+  },
+
   lowerThreshold: {
     type: Sequelize.FLOAT(2).UNSIGNED,
     allowNull: false,

--- a/packages/backend-api/src/models/user_category_assignment.ts
+++ b/packages/backend-api/src/models/user_category_assignment.ts
@@ -49,3 +49,5 @@ export const UserCategoryAssignment = sequelize.define<
     },
   },
 );
+
+UserCategoryAssignment.removeAttribute('id');

--- a/packages/backend-api/src/models/user_social_auth.ts
+++ b/packages/backend-api/src/models/user_social_auth.ts
@@ -34,6 +34,12 @@ export const UserSocialAuth = sequelize.define<
   IUserSocialAuthInstance,
   IUserSocialAuthAttributes
 >('user_social_auth', {
+  id: {
+    type: Sequelize.INTEGER.UNSIGNED,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+
   userId: {
     type: Sequelize.INTEGER.UNSIGNED,
     references: { model: User, key: 'id' },

--- a/packages/backend-api/src/test/domain/comments/fixture.ts
+++ b/packages/backend-api/src/test/domain/comments/fixture.ts
@@ -69,7 +69,7 @@ export function getCategoryData(data: Partial<ICategoryAttributes> = {}): ICateg
 }
 
 export async function createCategory(obj: Partial<ICategoryAttributes> = {}): Promise<ICategoryInstance> {
-  return await Category.create(getCategoryData(obj));
+  return Category.create(getCategoryData(obj));
 }
 
 // Articles
@@ -88,7 +88,7 @@ export function getArticleData(data: Partial<IArticleAttributes> = {}): IArticle
 }
 
 export async function createArticle(obj: Partial<IArticleAttributes> = {}): Promise<IArticleInstance> {
-  return await Article.create(getArticleData(obj));
+  return Article.create(getArticleData(obj));
 }
 
 export function getCommentData(data: Partial<ICommentAttributes> = {}): ICommentAttributes {
@@ -103,7 +103,7 @@ export function getCommentData(data: Partial<ICommentAttributes> = {}): IComment
 }
 
 export async function createComment(data?: any): Promise<ICommentInstance> {
-  return await Comment.create(getCommentData(data));
+  return Comment.create(getCommentData(data));
 }
 
 // Comment score requests
@@ -119,13 +119,13 @@ export function getCommentScoreRequestData(data: Partial<ICommentScoreRequestAtt
 }
 
 export async function createCommentScoreRequest(data?: object): Promise<ICommentScoreRequestInstance> {
-  return await CommentScoreRequest.create(getCommentScoreRequestData(data));
+  return CommentScoreRequest.create(getCommentScoreRequestData(data));
 }
 
 // Users
 
 export async function createUser(data: Partial<IUserAttributes> = {}): Promise<IUserInstance> {
-  return await User.create({
+  return User.create({
     group: 'general',
     email: faker.internet.email(),
     name: faker.name.firstName(),
@@ -135,7 +135,7 @@ export async function createUser(data: Partial<IUserAttributes> = {}): Promise<I
 }
 
 export async function createServiceUser(data: Partial<IUserAttributes> = {}): Promise<IUserInstance> {
-  return await User.create({
+  return User.create({
     group: USER_GROUP_SERVICE,
     name: faker.name.firstName(),
     isActive: true,
@@ -144,7 +144,7 @@ export async function createServiceUser(data: Partial<IUserAttributes> = {}): Pr
 }
 
 export async function createModeratorUser(data: Partial<IUserAttributes> = {}): Promise<IUserInstance> {
-  return await User.create({
+  return User.create({
     group: USER_GROUP_MODERATOR,
     name: faker.name.firstName(),
     isActive: true,
@@ -171,7 +171,7 @@ export function getCommentScoreData(data: Partial<ICommentScoreAttributes> = {})
 }
 
 export async function createCommentScore(data?: object): Promise<ICommentScoreInstance> {
-  return await CommentScore.create(getCommentScoreData(data));
+  return CommentScore.create(getCommentScoreData(data));
 }
 
 // Comment summary scores
@@ -186,7 +186,7 @@ export function getCommentSummaryScoreData(data: Partial<ICommentSummaryScoreAtt
 }
 
 export async function createCommentSummaryScore(data?: object): Promise<ICommentSummaryScoreInstance> {
-  return await CommentSummaryScore.create(getCommentSummaryScoreData(data));
+  return CommentSummaryScore.create(getCommentSummaryScoreData(data));
 }
 
 // Moderation rules
@@ -206,7 +206,7 @@ export function getModerationRuleData(data: Partial<IModerationRuleAttributes> =
 }
 
 export async function createModerationRule(data?: object): Promise<IModerationRuleInstance> {
-  return await ModerationRule.create(getModerationRuleData(data));
+  return ModerationRule.create(getModerationRuleData(data));
 }
 
 // Tags
@@ -223,5 +223,5 @@ export function getTagData(data: Partial<ITagAttributes> = {}): ITagAttributes {
 }
 
 export async function createTag(data?: object): Promise<ITagInstance> {
-  return await Tag.create(getTagData(data));
+  return Tag.create(getTagData(data));
 }

--- a/packages/backend-api/src/test/domain/comments/fixture.ts
+++ b/packages/backend-api/src/test/domain/comments/fixture.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import * as faker from 'faker';
 import { random, sample } from 'lodash';
+import { fn } from 'sequelize';
 import { underscored } from 'underscore.string';
 
 import {
@@ -57,7 +58,6 @@ import {
   USER_GROUP_MODERATOR,
   USER_GROUP_SERVICE,
 } from '../../../models';
-import { sequelize } from '../../../sequelize';
 
 // Category
 export function getCategoryData(data: Partial<ICategoryAttributes> = {}): ICategoryAttributes {
@@ -97,7 +97,7 @@ export function getCommentData(data: Partial<ICommentAttributes> = {}): IComment
     authorSourceId: faker.random.uuid(),
     text: faker.lorem.words(20),
     author: {},
-    sourceCreatedAt: sequelize.fn('now'),
+    sourceCreatedAt: fn('now'),
     ...data,
   } as ICommentAttributes;
 }
@@ -112,7 +112,7 @@ export function getCommentScoreRequestData(data: Partial<ICommentScoreRequestAtt
   return {
     commentId: faker.random.number(),
     userId: faker.random.number(),
-    sentAt: sequelize.fn('now'),
+    sentAt: fn('now'),
 
     ...data,
   };

--- a/packages/backend-api/src/test/fixture.ts
+++ b/packages/backend-api/src/test/fixture.ts
@@ -53,7 +53,7 @@ export { expect };
 
 let articleCounter = 0;
 export async function makeArticle(obj = {}): Promise<IArticleInstance> {
-  return await Article.create({
+  return Article.create({
     sourceId: `something ${articleCounter++}`,
     title: 'An article',
     text: 'Text',
@@ -67,7 +67,7 @@ export async function makeArticle(obj = {}): Promise<IArticleInstance> {
 }
 
 export async function makeUser(obj = {}): Promise<IUserInstance> {
-  return await User.create({
+  return User.create({
     group: 'general',
     name: 'Name',
     email: 'email@example.com',
@@ -77,7 +77,7 @@ export async function makeUser(obj = {}): Promise<IUserInstance> {
 }
 
 export async function makeTag(obj = {}): Promise<ITagInstance> {
-  return await Tag.create({
+  return Tag.create({
     key: 'test',
     label: 'Test',
     ...obj,
@@ -85,7 +85,7 @@ export async function makeTag(obj = {}): Promise<ITagInstance> {
 }
 
 export async function makeTaggingSensitivity(obj = {}): Promise<ITaggingSensitivityInstance> {
-  return await TaggingSensitivity.create({
+  return TaggingSensitivity.create({
     lowerThreshold: 0,
     upperThreshold: 1,
     ...obj,
@@ -94,7 +94,7 @@ export async function makeTaggingSensitivity(obj = {}): Promise<ITaggingSensitiv
 
 let commentCounter = 0;
 export async function makeComment(obj = {}): Promise<ICommentInstance> {
-  return await Comment.create({
+  return Comment.create({
     articleId: null,
     sourceId: `something ${commentCounter++}`,
     authorSourceId: 'something',
@@ -110,7 +110,7 @@ export async function makeComment(obj = {}): Promise<ICommentInstance> {
 }
 
 export async function makeCommentScore(obj = {}): Promise<ICommentScoreInstance> {
-  return await CommentScore.create({
+  return CommentScore.create({
     commentId: null,
     tagId: null,
     score: 1,
@@ -122,14 +122,14 @@ export async function makeCommentScore(obj = {}): Promise<ICommentScoreInstance>
 }
 
 export async function makeCommentSummaryScore(obj: Pick<ICommentSummaryScoreAttributes, 'commentId' | 'tagId' | 'score' | 'isConfirmed'>): Promise<ICommentSummaryScoreInstance> {
-  return await CommentSummaryScore.create({
+  return CommentSummaryScore.create({
     score: 1,
     ...obj,
   });
 }
 
 export async function makeCategory(obj = {}): Promise<ICategoryInstance> {
-  return await Category.create({
+  return Category.create({
     label: 'something',
     ...RESET_COUNTS,
     ...obj,
@@ -137,7 +137,7 @@ export async function makeCategory(obj = {}): Promise<ICategoryInstance> {
 }
 
 export async function makeRule(tag: ITagInstance, obj = {}): Promise<IModerationRuleInstance> {
-  return await ModerationRule.create({
+  return ModerationRule.create({
     tagId: tag.id,
     lowerThreshold: 0,
     upperThreshold: 1,
@@ -147,7 +147,7 @@ export async function makeRule(tag: ITagInstance, obj = {}): Promise<IModeration
 }
 
 export async function makePreselect(obj = {}): Promise<IPreselectInstance> {
-  return await Preselect.create({
+  return Preselect.create({
     lowerThreshold: 0,
     upperThreshold: 1,
     ...obj,
@@ -155,7 +155,7 @@ export async function makePreselect(obj = {}): Promise<IPreselectInstance> {
 }
 
 export async function makeFlag(obj: {}): Promise<ICommentFlagInstance> {
-  return await CommentFlag.create({
+  return CommentFlag.create({
     label: 'test flag',
     isResolved: false,
     ...obj,

--- a/packages/backend-api/src/test/integration/api/assignments.spec.ts
+++ b/packages/backend-api/src/test/integration/api/assignments.spec.ts
@@ -66,31 +66,6 @@ describe(BASE_URL, () => {
     user = await makeUser();
   });
 
-  describe('/users/:id/count', () => {
-    const url = `${BASE_URL}/users/:id/count`;
-
-    it('Fetch counts of assigned comments', async () => {
-      {
-        const apiClient = chai.request(app);
-        const {status, body} = await apiClient.get(url.replace(':id', user.id.toString()));
-        expect(status).to.be.equal(200);
-        expect(body.count).to.be.equal(0);
-      }
-
-      await ModeratorAssignment.create({
-        userId: user.id,
-        articleId: article.id,
-      });
-
-      {
-        const apiClient = chai.request(app);
-        const {status, body} = await apiClient.get(url.replace(':id', user.id.toString()));
-        expect(status).to.be.equal(200);
-        expect(body.count).to.be.equal(1);
-      }
-    });
-  });
-
   describe('/categories/:id', () => {
     const url = `${BASE_URL}/categories/:id`;
     it('Assign a moderator to a category', async () => {

--- a/packages/backend-api/src/test/integration/api/assistant.spec.ts
+++ b/packages/backend-api/src/test/integration/api/assistant.spec.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import * as chai from 'chai';
+import { fn } from 'sequelize';
 
 import {
   Comment,
@@ -24,7 +25,6 @@ import {
 import {
   ICommentScoreRequestInstance,
 } from '../../../models';
-import { sequelize } from '../../../sequelize';
 import {
   expect,
   makeComment,
@@ -53,7 +53,7 @@ describe(prefixed, () => {
       csRequest = await CommentScoreRequest.create({
         commentId: comment.id,
         userId: user.id,
-        sentAt: sequelize.fn('now'),
+        sentAt: fn('now'),
       });
 
       score = {


### PR DESCRIPTION
Some prerequisite changes for upgrade of Sequelize to V5.  

- In V5, the sequelize instance no longer provides sequelize constants and types.  These must be imported directly from the sequelize library.

- The V5 typings are good enough that they now highlight unnecessary uses of "return await" - we replace these with a straightforward return of a promise

We also fix a bug in the "assign moderators" entrypoint, probably introduced in the v4 update.