### PR TITLE
Introduce the getArticles endpoint

### DIFF
--- a/packages/backend-api/src/api/services/serializer.ts
+++ b/packages/backend-api/src/api/services/serializer.ts
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { pick } from 'lodash';
+import * as Sequelize from 'sequelize';
+
+export const TAG_FIELDS = ['id', 'color', 'description', 'key', 'label', 'isInBatchView', 'inSummaryScore', 'isTaggable'];
+export const RANGE_FIELDS = ['id', 'categoryId', 'lowerThreshold', 'upperThreshold', 'tagId'];
+export const TAGGING_SENSITIVITY_FIELDS = RANGE_FIELDS;
+export const RULE_FIELDS = ['action', 'createdBy', ...RANGE_FIELDS];
+export const PRESELECT_FIELDS = RANGE_FIELDS;
+export const USER_FIELDS = ['id', 'name', 'email', 'avatarURL', 'group', 'isActive'];
+
+const COMMENTSET_FIELDS = ['id', 'updatedAt', 'allCount', 'unprocessedCount', 'unmoderatedCount', 'moderatedCount',
+  'approvedCount', 'highlightedCount', 'rejectedCount', 'deferredCount', 'flaggedCount',
+  'batchedCount', 'recommendedCount', 'assignedModerators', ];
+export const CATEGORY_FIELDS = [...COMMENTSET_FIELDS, 'label', 'ownerId', 'isActive', 'sourceId'];
+export const ARTICLE_FIELDS = [...COMMENTSET_FIELDS, 'title', 'url', 'categoryId', 'sourceCreatedAt', 'lastModeratedAt',
+  'isCommentingEnabled', 'isAutoModerated'];
+
+const ID_FIELDS = new Set(['categoryId', 'tagId', 'ownerId']);
+
+// Convert IDs to strings, and assignedModerators to arrays of strings.
+export function serialiseObject(
+  o: Sequelize.Instance<any>,
+  fields: Array<string>,
+): {[key: string]: {} | Array<string> | string | number} {
+  const serialised = pick(o.toJSON(), fields);
+
+  serialised.id = serialised.id.toString();
+
+  for (const k in serialised) {
+    const v = serialised[k];
+
+    if (ID_FIELDS.has(k) && v) {
+      serialised[k] = v.toString();
+    }
+  }
+
+  if (serialised.assignedModerators) {
+    serialised.assignedModerators = serialised.assignedModerators.map(
+      (i: any) => (i.user_category_assignment ?  i.user_category_assignment.userId.toString() :
+        i.moderator_assignment.userId.toString()));
+  }
+  return serialised;
+}

--- a/packages/backend-api/src/api/services/simple.ts
+++ b/packages/backend-api/src/api/services/simple.ts
@@ -21,11 +21,13 @@ limitations under the License.
 
 import * as express from 'express';
 import { pick } from 'lodash';
+import { Op } from 'sequelize';
 
 import { createToken } from '../../auth/tokens';
 import { clearError } from '../../integrations';
 import {
   Article,
+  IArticleInstance,
   User,
   USER_GROUP_ADMIN,
   USER_GROUP_GENERAL,
@@ -37,6 +39,7 @@ import {
   updateHappened,
 } from '../../models';
 import { REPLY_SUCCESS } from '../constants';
+import { ARTICLE_FIELDS, serialiseObject } from './serializer';
 
 const userFields = ['id', 'name', 'email', 'group', 'isActive', 'extra'];
 
@@ -122,6 +125,16 @@ export function createSimpleRESTService(): express.Router {
 
     res.json(REPLY_SUCCESS);
     partialUpdateHappened(articleId);
+    next();
+  });
+
+  router.post('/article/get', async (req, res, next) => {
+    const articles = await Article.findAll({where: {id: {[Op.in]: req.body}}});
+    const articleData = articles.map((a: IArticleInstance) => {
+      return serialiseObject(a, ARTICLE_FIELDS);
+    });
+
+    res.json(articleData);
     next();
   });
 

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -25,6 +25,7 @@ import {
 } from './types';
 
 import {
+  ArticleModel,
   IAuthorCountsModel,
   ICommentDatedModel,
   ICommentModel,
@@ -476,7 +477,13 @@ export async function getModel<T>(
   };
 }
 
-export async function getArticleText(id: string) {
+export async function getArticles(ids: Array<ModelId>) {
+  const url = serviceURL('simple', `/article/get`);
+  const response = await axios.post(url, ids);
+  return response.data.map((a: any) => (ArticleModel(a)));
+}
+
+export async function getArticleText(id: ModelId) {
   const url = serviceURL('simple', `/article/${id}/text`);
   const response = await axios.get(url);
   return response.data.text;


### PR DESCRIPTION
This review introduces the getArticles endpoint.  The new articles cache will use this endpoint to fetch articles that are not in the cache.

The bulk of this change is just moving the update notification serialiser code into common code, so that it can be used by the new endpoint.  The endpoint itself is pretty trivial.