### PR TITLE
Article loader and injector

### DIFF
--- a/packages/frontend-web/src/app/components/AssignTagsForm/index.ts
+++ b/packages/frontend-web/src/app/components/AssignTagsForm/index.ts
@@ -20,7 +20,7 @@ import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
 import { IAppDispatch, IAppState } from '../../appstate';
-import { getArticle } from '../../stores/articles';
+import { articleInjector } from '../../injectors/articleInjector';
 import { getSummaryScoresById, loadCommentSummaryScores } from '../../stores/commentSummaryScores';
 import { getTaggingSensitivities } from '../../stores/taggingSensitivities';
 import { getTaggableTags } from '../../stores/tags';
@@ -30,7 +30,6 @@ import {
 } from './AssignTagsForm';
 
 const mapStateToProps = createStructuredSelector({
-  article: (state: IAppState, {articleId}) => getArticle(state, articleId),
   tags: (state: IAppState) => getTaggableTags(state),
 
   sensitivities: getTaggingSensitivities,
@@ -51,4 +50,5 @@ export type IAssignTagsFormProps = Pick<IPureAssignTagsFormProps, 'articleId'| '
 
 export const AssignTagsForm = compose<React.ComponentClass<IAssignTagsFormProps>>(
   connect(mapStateToProps, mapDispatchToProps),
+  articleInjector,
 )(PureAssignTagsForm);

--- a/packages/frontend-web/src/app/components/LazyLoadComment/CommentBodyStory.tsx
+++ b/packages/frontend-web/src/app/components/LazyLoadComment/CommentBodyStory.tsx
@@ -16,12 +16,14 @@ limitations under the License.
 
 import { storiesOf } from '@storybook/react';
 import faker from 'faker';
-import { List } from 'immutable';
+import { List, Map as IMap } from 'immutable';
 import React from 'react';
+import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { createStore } from 'redux';
 
 import { IAuthorModel } from '../../../models';
-import { fakeCommentModel } from '../../../models/fake';
+import { fakeArticleModel, fakeCommentModel } from '../../../models/fake';
 import { BasicBody, LinkedBasicBody } from './LazyLoadComment';
 
 const author = {
@@ -31,8 +33,10 @@ const author = {
   avatar: faker.internet.avatar(),
 } as IAuthorModel;
 
+const article = fakeArticleModel();
 const comment = fakeCommentModel({
   id: '-1',
+  articleId: article.id,
   replyId: null,
   isAccepted: true,
   isDeferred: false,
@@ -45,6 +49,11 @@ const comment = fakeCommentModel({
   flagsSummary: new Map([['red', List([1, 1, 0])]]),
   text: 'Founded in 1965 by Albert Griffiths, The Gladiators has released some of the most mythical songs of Jamaican reggae. Their first hit, the single Hello Carol, was released in 1968. In 1976, thanks to their signature at Virgin, the trilogy Trenchtown Mix Up, Proverbial Reggae and Naturality has been distributed all around the world and some of the songs of these albums have become classics of the reggae as Mix Up and Roots Natty Roots.',
 });
+
+export const store = createStore(
+  (s, _a) => s,
+  {global: {articles: {index: IMap([[article.id, article]])}}},
+);
 
 const returnEmpty = () => '';
 const returnFalse = () => false;
@@ -77,7 +86,7 @@ storiesOf('CommentBody', module)
       </div>
     );
   })
-  .add('Hide Comment cAtion', () => {
+  .add('Hide Comment Action', () => {
     return (
       <div>
         <BasicBody
@@ -87,5 +96,19 @@ storiesOf('CommentBody', module)
           handleAssignTagsSubmit={doNothing}
         />
       </div>
+    );
+  })
+  .add('Show Article', () => {
+    return (
+      <Provider store={store}>
+        <div>
+          <BasicBody
+            comment={comment}
+            dispatchConfirmedAction={returnFalse}
+            handleAssignTagsSubmit={doNothing}
+            displayArticleTitle
+          />
+        </div>
+      </Provider>
     );
   });

--- a/packages/frontend-web/src/app/components/LazyLoadComment/LazyLoadComment.tsx
+++ b/packages/frontend-web/src/app/components/LazyLoadComment/LazyLoadComment.tsx
@@ -20,8 +20,6 @@ import { List, Set } from 'immutable';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { OpenInNew } from '@material-ui/icons';
-
 import { ICommentModel, ModelId } from '../../../models';
 import {
   IConfirmationAction,
@@ -32,16 +30,12 @@ import { REQUIRE_REASON_TO_REJECT } from '../../config';
 import {
   articleBase,
   commentRepliesDetailsLink,
-  NEW_COMMENTS_DEFAULT_TAG,
-  newCommentsPageLink,
   searchLink,
 } from '../../scenes/routes';
 import {
-  ARTICLE_HEADLINE_TYPE,
   DARK_COLOR,
   MEDIUM_COLOR,
 } from '../../styles';
-import { COMMON_STYLES } from '../../stylesx';
 import { maybeCallback, partial } from '../../util';
 import { css } from '../../utilx';
 import { Avatar } from '../Avatar';
@@ -56,6 +50,7 @@ import {
 } from '../Icons';
 import { ModerateButtons } from '../ModerateButtons';
 import { ROW_STYLES } from '../styles';
+import { ArticleTitle } from './components';
 
 const LAZY_BOX_STYLE = {
   width: '100%',
@@ -167,30 +162,7 @@ export class BasicBody extends React.PureComponent<IBasicBodyProps, IBasicBodySt
         onMouseLeave={this.mouseLeave}
         {...css(ROW_STYLES.comment, {flex: 1})}
       >
-        {displayArticleTitle && (
-          <div key="title">
-            <Link
-              key="text"
-              {...css(ROW_STYLES.articleLink)}
-              to={newCommentsPageLink({
-                context: articleBase,
-                contextId: comment.article.id,
-                tag: NEW_COMMENTS_DEFAULT_TAG,
-              })}
-            >
-              <h4 {...css(ARTICLE_HEADLINE_TYPE, { marginBottom: '0px', marginTop: '0px'  })}>
-                {comment.article.title}
-              </h4>
-            </Link>
-            {comment.article.url && (
-            <div key="link" style={{display: 'inline-block', margin: '0 10px', position: 'relative', top: '3px'}}>
-              <a href={comment.article.url} target="_blank" {...css(COMMON_STYLES.cellLink)}>
-                <OpenInNew fontSize="small"/>
-              </a>
-            </div>
-          )}
-          </div>
-        )}
+        {displayArticleTitle && <ArticleTitle articleId={comment.articleId}/>}
         <div key="body" {...css(ROW_STYLES.meta)}>
           <div key="text" {...css(ROW_STYLES.authorRow)}>
             { comment.replyToSourceId > 0 && (

--- a/packages/frontend-web/src/app/components/LazyLoadComment/components.tsx
+++ b/packages/frontend-web/src/app/components/LazyLoadComment/components.tsx
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { OpenInNew } from '@material-ui/icons';
+
+import { IArticleModel } from '../../../models';
+import { articleInjector } from '../../injectors/articleInjector';
+import { articleBase, NEW_COMMENTS_DEFAULT_TAG, newCommentsPageLink } from '../../scenes/routes';
+import { ARTICLE_HEADLINE_TYPE } from '../../styles';
+import { COMMON_STYLES } from '../../stylesx';
+import { css } from '../../utilx';
+import { ROW_STYLES } from '../styles';
+
+function _ArticleTitle({article}: {article: IArticleModel}) {
+  return (
+    <div key="title" style={{display: 'flex'}}>
+      <Link
+        key="text"
+        {...css(ROW_STYLES.articleLink)}
+        to={newCommentsPageLink({
+          context: articleBase,
+          contextId: article.id,
+          tag: NEW_COMMENTS_DEFAULT_TAG,
+        })}
+      >
+        <h4 {...css(ARTICLE_HEADLINE_TYPE, { marginBottom: '0px', marginTop: '0px'  })}>
+          {article.title}
+        </h4>
+      </Link>
+      {article.url && (
+        <div key="link" style={{display: 'inline-block', margin: '0 10px', position: 'relative', top: '3px'}}>
+          <a href={article.url} target="_blank" {...css(COMMON_STYLES.cellLink)}>
+            <OpenInNew fontSize="small"/>
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const ArticleTitle = articleInjector(_ArticleTitle);

--- a/packages/frontend-web/src/app/injectors/articleInjector.ts
+++ b/packages/frontend-web/src/app/injectors/articleInjector.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { connect } from 'react-redux';
+
+import { ModelId } from '../../models';
+import { IAppState } from '../appstate';
+import { getCachedArticle, IArticleCacheProps } from './fetchQueues';
+
+export interface IArticleInjectorInputProps {
+  articleId: ModelId;
+}
+
+function mapStateToProps(state: IAppState, {articleId}: IArticleInjectorInputProps): IArticleCacheProps {
+  return getCachedArticle(state, articleId);
+}
+
+export const articleInjector = connect(mapStateToProps);

--- a/packages/frontend-web/src/app/injectors/contextInjector.ts
+++ b/packages/frontend-web/src/app/injectors/contextInjector.ts
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import {connect} from 'react-redux';
+import {RouteComponentProps} from 'react-router';
+
+import {IArticleModel, ICategoryModel, ModelId} from '../../models';
+import {IAppState} from '../appstate';
+import {IContextPathParams, isArticleContext} from '../scenes/routes';
+import {getCategory} from '../stores/categories';
+import {getCachedArticle} from './fetchQueues';
+
+export interface IContextInjectorProps {
+  isArticleContext: boolean;
+  categoryId: ModelId;
+  category?: ICategoryModel;
+  articleId?: ModelId;
+  article?: IArticleModel;
+  inCache: boolean;
+}
+
+function mapStateToProps(
+  state: IAppState,
+  {match: {params}}: RouteComponentProps<IContextPathParams>,
+): IContextInjectorProps & {inCache: boolean} {
+  if (!isArticleContext(params)) {
+    return {
+      isArticleContext: false,
+      categoryId: params.contextId,
+      category: getCategory(state, params.contextId),
+      inCache: true,
+    };
+  }
+
+  const articleId = params.contextId;
+  const {article, inCache} = getCachedArticle(state, articleId);
+  return {
+    isArticleContext: true,
+    categoryId: article.categoryId,
+    category: getCategory(state, article.categoryId),
+    articleId,
+    article,
+    inCache,
+  };
+}
+
+export const contextInjector = connect(mapStateToProps);

--- a/packages/frontend-web/src/app/injectors/fetchQueues.ts
+++ b/packages/frontend-web/src/app/injectors/fetchQueues.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import {IArticleModel, ModelId} from '../../models';
+import {IAppState} from '../appstate';
+import {getArticles} from '../platform/dataService';
+import {store} from '../store';
+import {articlesUpdated} from '../stores/articles';
+
+const articleFetchQueue = new Set();
+
+export interface IArticleCacheProps {
+  article: IArticleModel;
+  inCache: boolean;
+}
+
+async function fetchArticle(articleId: ModelId) {
+  const articles = await getArticles([articleId]);
+  store.dispatch(articlesUpdated(articles));
+}
+
+function ensureCache(articleId: ModelId) {
+  if (!articleFetchQueue.has(articleId)) {
+    articleFetchQueue.add(articleId);
+    fetchArticle(articleId);
+  }
+}
+
+export function getCachedArticle(state: IAppState, articleId: ModelId): {article: IArticleModel, inCache: boolean} {
+  const article: IArticleModel = state.global.articles.index.get(articleId);
+  if (article) {
+    articleFetchQueue.delete(articleId);
+    return {article, inCache: true};
+  }
+
+  ensureCache(articleId);
+
+  return {
+    inCache: false,
+    article: {
+      id: articleId,
+      sourceCreatedAt: '',
+      updatedAt: '',
+      title: '',
+      text: '',
+      url: '',
+      categoryId: 'any',
+      allCount: 0,
+      unprocessedCount: 0,
+      unmoderatedCount: 0,
+      moderatedCount: 0,
+      deferredCount: 0,
+      approvedCount: 0,
+      highlightedCount: 0,
+      rejectedCount: 0,
+      flaggedCount: 0,
+      batchedCount: 0,
+      automatedCount: 0,
+      lastModeratedAt: '',
+      assignedModerators: new Array<ModelId>(),
+      isCommentingEnabled: true,
+      isAutoModerated: true,
+    },
+  };
+}

--- a/packages/frontend-web/src/app/scenes/Comments/components/ModeratedComments/index.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/components/ModeratedComments/index.ts
@@ -21,7 +21,7 @@ import { createStructuredSelector } from 'reselect';
 
 import { ICommentAction } from '../../../../../types';
 import { IAppDispatch, IAppState } from '../../../../appstate';
-import { getArticle } from '../../../../stores/articles';
+import {contextInjector, IContextInjectorProps} from '../../../../injectors/contextInjector';
 import {
   approveComments,
   approveFlagsAndComments,
@@ -34,7 +34,7 @@ import {
 } from '../../../../stores/commentActions';
 import { getTaggableTags } from '../../../../stores/tags';
 import { getTextSizes, getTextSizesIsLoading } from '../../../../stores/textSizes';
-import { IModeratedCommentsPathParams, IModeratedCommentsQueryParams, isArticleContext } from '../../../routes';
+import { IModeratedCommentsPathParams, IModeratedCommentsQueryParams } from '../../../routes';
 import {
   IModeratedCommentsProps,
   ModeratedComments as PureModeratedComments,
@@ -47,8 +47,7 @@ import {
   getIsLoading,
   getModeratedComments,
   loadCommentList,
-  setCommentsModerationForArticle,
-  setCommentsModerationForCategory,
+  setCommentsModerationStatus,
   toggleSelectAll,
   toggleSingleItem,
 } from './store';
@@ -57,8 +56,7 @@ type IModeratedCommentsDispatchProps = Pick<
   IModeratedCommentsProps,
   'toggleSelectAll' |
   'toggleSingleItem' |
-  'setCommentModerationStatusForArticle' |
-  'setCommentModerationStatusForCategory' |
+  'setCommentModerationStatus' |
   'loadData' |
   'tagComments' |
   'dispatchAction'
@@ -66,12 +64,6 @@ type IModeratedCommentsDispatchProps = Pick<
 
 const mapStateToProps = createStructuredSelector({
   isLoading: (state: IAppState) => (getIsLoading(state) || getTextSizesIsLoading(state)),
-
-  article: (state: IAppState, { match: { params }}: IModeratedCommentsProps) => {
-    if (isArticleContext(params)) {
-      return getArticle(state, params.contextId);
-    }
-  },
 
   areNoneSelected: getAreAnyCommentsSelected,
 
@@ -117,11 +109,13 @@ function mapDispatchToProps(dispatch: IAppDispatch, props: IModeratedCommentsPro
 
     toggleSingleItem: ({ id }: { id: string }) => dispatch(toggleSingleItem({ id })),
 
-    setCommentModerationStatusForArticle: (commentIds: Array<string>, moderationAction: string, currentModeration: string) =>
-        setCommentsModerationForArticle(dispatch, props.match.params.contextId, commentIds, moderationAction, currentModeration),
-
-    setCommentModerationStatusForCategory: (commentIds: Array<string>, moderationAction: string, currentModeration: string) =>
-        setCommentsModerationForCategory(dispatch, props.match.params.contextId, commentIds, moderationAction, currentModeration),
+    setCommentModerationStatus: (
+      iprops: IContextInjectorProps,
+      commentIds: Array<string>,
+      moderationAction: string,
+      currentModeration: string,
+    ) =>
+        setCommentsModerationStatus(dispatch, iprops, commentIds, moderationAction, currentModeration),
   };
 }
 
@@ -132,6 +126,7 @@ export const ModeratedComments: React.ComponentClass = compose(
     mapDispatchToProps,
   ),
   withRouter,
+  contextInjector,
 )(PureModeratedComments);
 
 export * from './store';

--- a/packages/frontend-web/src/app/scenes/Comments/components/NewComments/NewComments.tsx
+++ b/packages/frontend-web/src/app/scenes/Comments/components/NewComments/NewComments.tsx
@@ -29,7 +29,6 @@ import {
 
 import {
   convertServerAction,
-  IArticleModel,
   ICommentDatedModel,
   ICommentModel,
   ICommentScoredModel,
@@ -57,6 +56,7 @@ import {
   DEFAULT_DRAG_HANDLE_POS1,
   DEFAULT_DRAG_HANDLE_POS2,
 } from '../../../../config';
+import { IContextInjectorProps } from '../../../../injectors/contextInjector';
 import { updateArticle } from '../../../../platform/dataService';
 import { getDefaultSort, putDefaultSort } from '../../../../util/savedSorts';
 import {
@@ -85,7 +85,6 @@ import {
   commentDetailsPageLink,
   INewCommentsPathParams,
   INewCommentsQueryParams,
-  isArticleContext,
   newCommentsPageLink,
   tagSelectorLink,
 } from '../../../routes';
@@ -249,8 +248,7 @@ const STYLES = stylesheet({
   },
 });
 
-export interface INewCommentsProps extends RouteComponentProps<INewCommentsPathParams> {
-  article?: IArticleModel;
+export interface INewCommentsProps extends RouteComponentProps<INewCommentsPathParams>, IContextInjectorProps {
   preselects?: List<IPreselectModel>;
   commentScores: List<ICommentScoredModel | ICommentDatedModel>;
   isLoading: boolean;
@@ -334,8 +332,7 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
     let preselect: IPreselectModel;
     const params = props.match.params;
     const tag = params.tag;
-    const categoryId = (!isArticleContext(params)) ? params.contextId : props.article.categoryId;
-    const articleId = (isArticleContext(params)) ? params.contextId : null;
+    const {categoryId, articleId} = props;
     let defaultPos1: number;
     let defaultPos2: number;
     let defaultSort;
@@ -348,14 +345,17 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
 
     if (tag !== 'DATE') {
       if (props.preselects) {
-        if (categoryId && categoryId !== 'all' && props.selectedTag) {
-          preselect = props.preselects.find((p) => (p.categoryId === categoryId && p.tagId === props.selectedTag.id));
+        if (categoryId !== 'all' && props.selectedTag) {
+          preselect = props.preselects.find((p) =>
+            (p.categoryId === categoryId && p.tagId === props.selectedTag.id));
         }
-        if (!preselect && categoryId && categoryId !== 'all') {
-          preselect = props.preselects.find((p) => (p.categoryId === categoryId && !p.tagId));
+        if (!preselect && categoryId !== 'all') {
+          preselect = props.preselects.find((p) =>
+            (p.categoryId === categoryId && !p.tagId));
         }
         if (!preselect && props.selectedTag) {
-          preselect = props.preselects.find((p) => (!p.categoryId && p.tagId === props.selectedTag.id));
+          preselect = props.preselects.find((p) =>
+            (!p.categoryId && p.tagId === props.selectedTag.id));
         }
         if (!preselect) {
           preselect = props.preselects.find((p) => (!p.categoryId && !p.tagId));
@@ -383,8 +383,9 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
 
     let rulesInCategory: List<IRuleModel>;
     if (props.rules) {
-      if (categoryId && categoryId !== 'all') {
-        rulesInCategory = props.rules.filter((r) => (r.categoryId === categoryId || !r.categoryId)) as List<IRuleModel>;
+      if (categoryId !== 'all') {
+        rulesInCategory = props.rules.filter((r) =>
+          (r.categoryId === categoryId || !r.categoryId)) as List<IRuleModel>;
       }
       else {
         rulesInCategory = props.rules.filter((r) => (!r.categoryId)) as List<IRuleModel>;
@@ -471,6 +472,7 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
 
   render() {
     const {
+      isArticleContext,
       article,
       commentScores,
       textSizes,
@@ -592,7 +594,7 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
               </Link>
               <span aria-hidden="true" {...css(STYLES.arrow)} />
             </div>
-            { isArticleContext(params) && (
+            { isArticleContext && (
               <ArticleControlIcon
                 article={article}
                 open={this.state.articleControlOpen}
@@ -752,7 +754,7 @@ export class NewComments extends React.Component<INewCommentsProps, INewComments
               totalItems={commentIds.size}
               triggerActionToast={this.triggerActionToast}
               dispatchConfirmedAction={this.dispatchConfirmedAction}
-              displayArticleTitle={!isArticleContext(params)}
+              displayArticleTitle={!isArticleContext}
               onTableScroll={this.onTableScroll}
             />
           )}

--- a/packages/frontend-web/src/app/scenes/Comments/components/NewComments/index.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/components/NewComments/index.ts
@@ -21,7 +21,7 @@ import { createStructuredSelector } from 'reselect';
 
 import { ICommentAction } from '../../../../../types';
 import { IAppDispatch, IAppState } from '../../../../appstate';
-import { getArticle } from '../../../../stores/articles';
+import { contextInjector } from '../../../../injectors/contextInjector';
 import {
   approveComments,
   confirmCommentSummaryScore,
@@ -44,7 +44,6 @@ import { getTaggableTags } from '../../../../stores/tags';
 import { getTextSizes, getTextSizesIsLoading } from '../../../../stores/textSizes';
 import {
   INewCommentsPathParams,
-  isArticleContext,
 } from '../../../routes';
 import {
   INewCommentsProps,
@@ -113,12 +112,6 @@ function mapDispatchToProps(dispatch: IAppDispatch): Partial<INewCommentsProps> 
 }
 
 const mapStateToProps = createStructuredSelector({
-  article: (state: IAppState, { match: { params }}: INewCommentsProps) => {
-    if (isArticleContext(params)) {
-      return getArticle(state, params.contextId);
-    }
-  },
-
   preselects: getPreselects,
 
   getComment: (state: IAppState) => (id: string) => (getComment(state, id)),
@@ -149,6 +142,7 @@ const mapStateToProps = createStructuredSelector({
 export const NewComments = compose(
   withRouter,
   connect(mapStateToProps, mapDispatchToProps),
+  contextInjector,
 )(PureNewComments) as any;
 
 export * from './store';

--- a/packages/frontend-web/src/app/scenes/Comments/index.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/index.ts
@@ -19,11 +19,9 @@ import { withRouter } from 'react-router';
 import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
 
-import { IAppState } from '../../appstate';
-import { getArticle } from '../../stores/articles';
-import { getCategory, getGlobalCounts } from '../../stores/categories';
-import { isArticleContext } from '../routes';
-import { Comments as PureComments, ICommentsProps } from './Comments';
+import { contextInjector } from '../../injectors/contextInjector';
+import { getGlobalCounts } from '../../stores/categories';
+import { Comments as PureComments } from './Comments';
 
 export { NewComments } from './components/NewComments';
 export { TagSelector } from './components/TagSelector';
@@ -33,20 +31,9 @@ export { ThreadedCommentDetail } from './components/ThreadedCommentDetail';
 
 export const Comments = compose(
   connect(createStructuredSelector({
-      article: (state: IAppState, {  match: { params }}: ICommentsProps) => (
-        isArticleContext(params) && getArticle(state, params.contextId)
-      ),
-      category: (state: IAppState, {  match: { params }}: ICommentsProps) => {
-        if (isArticleContext(params)) {
-          const article = getArticle(state, params.contextId);
-          return getCategory(state, article.categoryId);
-        }
-        else if (params.contextId !== 'all') {
-          return getCategory(state, params.contextId);
-        }
-      },
       globalCounts: getGlobalCounts,
     }),
   ),
   withRouter,
+  contextInjector,
 )(PureComments);

--- a/packages/frontend-web/src/models/comment.ts
+++ b/packages/frontend-web/src/models/comment.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { fromJS, List, Record } from 'immutable';
 import { TypedRecord } from 'typed-immutable-record';
-import { IArticleModel } from './article';
 
 export interface IAuthorAttributes {
   email: string;
@@ -56,7 +55,6 @@ export interface ICommentAttributes {
   flagsSummary?: Map<string, List<number>>;
   sentForScoring: boolean;
   articleId: string;
-  article: IArticleModel;
   replies?: Array<ICommentModel>;
   maxSummaryScore?: number;
   maxSummaryScoreTagId?: string;

--- a/packages/frontend-web/src/models/fake/comment.ts
+++ b/packages/frontend-web/src/models/fake/comment.ts
@@ -17,10 +17,8 @@ limitations under the License.
 import faker from 'faker';
 import { CommentModel, IAuthorModel, ICommentAttributes, ICommentModel } from '../comment';
 import { CommentFlagModel, ICommentFlagAttributes, ICommentFlagModel } from '../commentFlag';
-import { fakeArticleModel } from './article';
 
 export function fakeCommentModel(overrides: Partial<ICommentAttributes> = {}): ICommentModel {
-  const article = (overrides && overrides['article']) || fakeArticleModel();
   const author = {
     email: faker.internet.email(),
     location: faker.address.city(),
@@ -46,8 +44,7 @@ export function fakeCommentModel(overrides: Partial<ICommentAttributes> = {}): I
     unresolvedFlagsCount: faker.random.number(),
     sourceCreatedAt: faker.date.recent().toISOString(),
     sentForScoring: faker.random.boolean(),
-    articleId: article.id && undefined,
-    article,
+    articleId: undefined,
     updatedAt: faker.date.recent().toISOString(),
     ...overrides,
   });


### PR DESCRIPTION
After all that groundwork, introduce the article loader code.

This review introduces the concept of an injector.  This is a reusable component that knows how to extract useful information out of the route and store and assign it to attributes of a component.  This saves us from having to duplicate this code in every `mapStateToProps`.  Also, avoiding the use of `createStructuredSelector` allows us to be a lot more flexible.

It also introduces a simple fetch queue.  Each article is fetched individually, and stored in the article cache in the store.  Until the article arrives, the injector just injects a dummy placeholder.

We tested this by modifying the backend to not send articles in websocket events.  All articles are then fetched on demand by the injector.

Future developments will do the following:
 - Create an injector, fetch queue and cache for comments, using the article injector as a model.
 - Enhance the fetch queue to batch fetch requests
 - Enhance the cache to flush entries that are no longer required.  
 - Improve efficiency of the initial websocket event by only sending recent and active articles. 