### PR TITLE
Introduce comment injector

### DIFF
--- a/packages/frontend-web/src/app/components/SingleComment/SingleComment.tsx
+++ b/packages/frontend-web/src/app/components/SingleComment/SingleComment.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import { autobind } from 'core-decorators';
 import formatDate from 'date-fns/format';
 import { List } from 'immutable';
-import React from 'react';
+import React, {Fragment} from 'react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -501,6 +501,74 @@ export class SingleComment extends React.PureComponent<ISingleCommentProps, ISin
     this.authorLocation.focus();
   }
 
+  renderAuthor() {
+    const {comment} = this.props;
+    const {inEditMode} = this.state;
+
+    const { author } = this.props.comment;
+    if (!author) {
+      return null;
+    }
+    return (
+      <Fragment>
+        {author.avatar && <Avatar key="avatarColumn" target={author} size={60}/>}
+        <div key="nameColumn" {...css(PROFILE_STYLES.nameColumn)}>
+          <div {...css(PROFILE_STYLES.name)}>
+            {!inEditMode ? (
+              <Link
+                to={searchLink({searchByAuthor: true, term: author.name})}
+                key="authorName"
+                {...css(PROFILE_STYLES.authorName)}
+              >
+                {author.name}
+              </Link>
+            ) : (
+              <span
+                key="authorNameEditable"
+                contentEditable
+                suppressContentEditableWarning
+                ref={this.saveAuthorNameRef}
+                onClick={this.focusName}
+                {...css(STYLES.contentEditableContainer, {minWidth: '300px'})}
+              >
+                {author.name}
+              </span>
+            )}
+          </div>
+          <div {...css(PROFILE_STYLES.meta)}>
+            <div>
+              {author.location && (
+                <div key="location" {...css(PROFILE_STYLES.location)}>
+                  {!inEditMode ? (
+                    <span key="authorLocation">{author.location}</span>
+                  ) : (
+                    <span
+                      key="authorLocationEditable"
+                      contentEditable
+                      suppressContentEditableWarning
+                      ref={this.saveAuthorLocationRef}
+                      onClick={this.focusLocation}
+                      {...css(STYLES.contentEditableContainer)}
+                    >
+                      {author.location}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+            <div {...css(PROFILE_STYLES.details)}>
+              <AuthorCounts authorSourceId={comment.authorSourceId}/>
+              {author.approvalRating && (<ApprovalRatingRow approvalRating={author.approvalRating}/>)}
+              {author.isSubscriber && (<IsSubscriberRow/>)}
+              {author.email && (<EmailRow author={author}/>)}
+              {comment.authorSourceId && (<SourceIdRow authorSourceId={comment.authorSourceId}/>)}
+            </div>
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
+
   render() {
     const {
       comment,
@@ -530,7 +598,6 @@ export class SingleComment extends React.PureComponent<ISingleCommentProps, ISin
       isEditFocused,
     } = this.state;
 
-    const { author } = comment;
     const SUBMITTED_AT = formatDate(comment.sourceCreatedAt, DATE_FORMAT_LONG);
 
     const bodyStyling = css(COMMENT_STYLES.body);
@@ -545,63 +612,7 @@ export class SingleComment extends React.PureComponent<ISingleCommentProps, ISin
           )}
         >
           <div {...css(PROFILE_STYLES.header)}>
-            {author.avatar && <Avatar key="avatarColumn" target={author} size={60}/>}
-            <div key="nameColumn" {...css(PROFILE_STYLES.nameColumn)}>
-              <div {...css(PROFILE_STYLES.name)}>
-                {!inEditMode ? (
-                  <Link
-                    to={searchLink({searchByAuthor: true, term: author.name})}
-                    key="authorName"
-                    {...css(PROFILE_STYLES.authorName)}
-                  >
-                    {author.name}
-                  </Link>
-                ) : (
-                  <span
-                    key="authorNameEditable"
-                    contentEditable
-                    suppressContentEditableWarning
-                    ref={this.saveAuthorNameRef}
-                    onClick={this.focusName}
-                    {...css(STYLES.contentEditableContainer, {minWidth: '300px'})}
-                  >
-                    {author.name}
-                  </span>
-                )
-                }
-              </div>
-
-              <div {...css(PROFILE_STYLES.meta)}>
-                <div>
-                  {author.location && (
-                    <div key="location" {...css(PROFILE_STYLES.location)}>
-                      {!inEditMode ? (
-                        <span key="authorLocation">{author.location}</span>
-                      ) : (
-                        <span
-                          key="authorLocationEditable"
-                          contentEditable
-                          suppressContentEditableWarning
-                          ref={this.saveAuthorLocationRef}
-                          onClick={this.focusLocation}
-                          {...css(STYLES.contentEditableContainer)}
-                        >
-                          {author.location}
-                        </span>
-                      )
-                      }
-                    </div>
-                  )}
-                </div>
-                <div {...css(PROFILE_STYLES.details)}>
-                  <AuthorCounts authorSourceId={comment.authorSourceId}/>
-                  {author.approvalRating && (<ApprovalRatingRow approvalRating={author.approvalRating}/>)}
-                  {author.isSubscriber && (<IsSubscriberRow/>)}
-                  {author.email && (<EmailRow author={author}/>)}
-                  {comment.authorSourceId && (<SourceIdRow authorSourceId={comment.authorSourceId}/>)}
-                </div>
-              </div>
-            </div>
+            {this.renderAuthor()}
           </div>
         </div>
         <div {...css(COMMENT_STYLES.base)}>

--- a/packages/frontend-web/src/app/injectors/commentFetchQueue.ts
+++ b/packages/frontend-web/src/app/injectors/commentFetchQueue.ts
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import {CommentModel, ICommentModel, ModelId} from '../../models';
+import {IAppState} from '../appstate';
+import {fetchComments} from '../stores/commentActions';
+
+const commentFetchQueue = new Set();
+
+export interface ICommentCacheProps {
+  comment: ICommentModel;
+  inCache: boolean;
+}
+
+function ensureCache(commentId: ModelId) {
+  if (!commentFetchQueue.has(commentId)) {
+    commentFetchQueue.add(commentId);
+    fetchComments([commentId]);
+  }
+}
+
+export function getCachedComment(state: IAppState, commentId: ModelId): ICommentCacheProps {
+  const comment: ICommentModel = state.global.newComments.index.get(commentId);
+  if (comment) {
+    commentFetchQueue.delete(commentId);
+    return {comment, inCache: true};
+  }
+
+  ensureCache(commentId);
+
+  return {
+    inCache: false,
+    comment: CommentModel({
+      id: commentId,
+      sourceId: '',
+      sourceCreatedAt: '',
+      updatedAt: '',
+      replyId: null,
+      replyToSourceId: null,
+      authorSourceId: null,
+      text: null,
+      author: null,
+      isScored: null,
+      isModerated: null,
+      isAccepted: null,
+      isDeferred: null,
+      isHighlighted: null,
+      isBatchResolved: null,
+      isAutoResolved: null,
+      unresolvedFlagsCount: null,
+      flagsSummary: null,
+      sentForScoring: null,
+      articleId: null,
+      replies: null,
+      maxSummaryScore: null,
+      maxSummaryScoreTagId: null,
+    }),
+  };
+}

--- a/packages/frontend-web/src/app/injectors/commentFetchQueue.ts
+++ b/packages/frontend-web/src/app/injectors/commentFetchQueue.ts
@@ -50,7 +50,7 @@ export function getCachedComment(state: IAppState, commentId: ModelId): IComment
       replyId: null,
       replyToSourceId: null,
       authorSourceId: null,
-      text: null,
+      text: '',
       author: null,
       isScored: null,
       isModerated: null,

--- a/packages/frontend-web/src/app/injectors/commentInjector.ts
+++ b/packages/frontend-web/src/app/injectors/commentInjector.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { connect } from 'react-redux';
+
+import { ModelId } from '../../models';
+import { IAppState } from '../appstate';
+import { getCachedComment, ICommentCacheProps } from './commentFetchQueue';
+
+export interface ICommentInjectorInputProps {
+  commentId: ModelId;
+}
+
+function mapStateToProps(state: IAppState, {commentId}: ICommentInjectorInputProps): ICommentCacheProps {
+  return getCachedComment(state, commentId);
+}
+
+export const commentInjector = connect(mapStateToProps);

--- a/packages/frontend-web/src/app/injectors/commentInjector.ts
+++ b/packages/frontend-web/src/app/injectors/commentInjector.ts
@@ -14,17 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 
 import { ModelId } from '../../models';
 import { IAppState } from '../appstate';
+import { ICommentDetailsPathParams } from '../scenes/routes';
 import { getCachedComment, ICommentCacheProps } from './commentFetchQueue';
 
 export interface ICommentInjectorInputProps {
   commentId: ModelId;
 }
 
-function mapStateToProps(state: IAppState, {commentId}: ICommentInjectorInputProps): ICommentCacheProps {
+function getCommentFromCommentId(state: IAppState, {commentId}: ICommentInjectorInputProps): ICommentCacheProps {
   return getCachedComment(state, commentId);
 }
 
-export const commentInjector = connect(mapStateToProps);
+export const commentInjector = connect(getCommentFromCommentId);
+
+function getCommentFromRoute(state: IAppState, props: RouteComponentProps<ICommentDetailsPathParams>): ICommentCacheProps {
+  return getCachedComment(state, props.match.params.commentId);
+}
+
+export const commentFromRouteInjector = connect(getCommentFromRoute);

--- a/packages/frontend-web/src/app/scenes/Comments/components/CommentDetail/CommentDetail.tsx
+++ b/packages/frontend-web/src/app/scenes/Comments/components/CommentDetail/CommentDetail.tsx
@@ -106,9 +106,6 @@ import {
   getSensitivitiesForCategory,
 } from '../../scoreFilters';
 import { Shortcuts } from '../Shortcuts';
-import {
-  getTaggingSensitivityForTag,
-} from './store';
 
 const ACTION_PROPERTY_MAP: {
   [key: string]: string | null;
@@ -354,7 +351,6 @@ export interface ICommentDetailProps extends RouteComponentProps<ICommentDetails
   nextCommentId?: string;
   previousCommentId?: string;
   isFromBatch?: boolean;
-  isLoading?: boolean;
   onUpdateCommentScore?(commentScore: ICommentScoreModel): void;
   onUpdateComment?(comment: ICommentModel): void;
   onAddCommentScore?(commentScore: ICommentScoreModel): void;
@@ -431,6 +427,7 @@ export class CommentDetail extends React.Component<ICommentDetailProps, IComment
     if (prevState.loadedCommentId !== nextProps.match.params.commentId) {
       nextProps.loadData(nextProps.match.params.commentId);
     }
+
     return {
       taggingSensitivitiesInCategory: sensitivities,
       allScoresAboveThreshold,
@@ -564,7 +561,6 @@ export class CommentDetail extends React.Component<ICommentDetailProps, IComment
                 vertical
                 activeButtons={activeButtons}
                 onClick={this.moderateComment}
-                disabled={this.props.isLoading}
                 requireReasonForReject={comment.isAccepted === false ? false : REQUIRE_REASON_TO_REJECT}
                 comment={comment}
                 handleAssignTagsSubmit={this.handleAssignTagsSubmit}
@@ -633,7 +629,7 @@ export class CommentDetail extends React.Component<ICommentDetailProps, IComment
 
           <div {...css(STYLES.commentWrapper)}>
             <div {...css(STYLES.comment)}>
-              { comment.replyId && !this.props.isLoading && (
+              { comment.replyId && (
                 <ReplyLink parent={comment} commentId={comment.replyId}/>
               )}
               <SingleComment
@@ -1068,7 +1064,8 @@ export class CommentDetail extends React.Component<ICommentDetailProps, IComment
 
   @autobind
   handleScoreClick(scoreClicked: ICommentSummaryScoreModel2) {
-    const thresholdByTag = getTaggingSensitivityForTag(this.state.taggingSensitivitiesInCategory, scoreClicked.tagId);
+    const thresholdByTag = this.state.taggingSensitivitiesInCategory.find(
+      (ts) => ts.tagId === scoreClicked.tagId || ts.categoryId === null);
     const scoresSelectedByTag = this.props.allScores.filter(
       (score) => score.tagId === scoreClicked.tagId,
     ).sort((a, b) => b.score - a.score);

--- a/packages/frontend-web/src/app/scenes/Comments/components/CommentDetail/index.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/components/CommentDetail/index.ts
@@ -27,7 +27,8 @@ import {
 } from '../../../../../models';
 import { IConfirmationAction } from '../../../../../types';
 import { IAppDispatch, IAppState } from '../../../../appstate';
-import { updateComment as updateCommentState } from '../../../../stores/comments';
+import { commentFromRouteInjector } from '../../../../injectors/commentInjector';
+import { commentsUpdated, updateComment as updateCommentState } from '../../../../stores/comments';
 import { getTaggingSensitivities } from '../../../../stores/taggingSensitivities';
 import { getTaggableTags } from '../../../../stores/tags';
 import { getCurrentUser, getUser } from '../../../../stores/users';
@@ -35,19 +36,15 @@ import { updateCommentStateAction } from '../ModeratedComments/store';
 import { CommentDetail as PureCommentDetail, ICommentDetailProps } from './CommentDetail';
 import {
   addCommentScore,
-  getComment,
   getCurrentCommentIndex,
-  getIsLoading,
   getNextCommentId,
   getPagingIsFromBatch,
   getPagingLink,
   getPagingSource,
   getPreviousCommentId,
   getScores,
-  loadComment,
   loadScores,
   removeCommentScore,
-  updateComment,
   updateCommentScore,
 } from './store';
 
@@ -70,8 +67,6 @@ function getPagingIdentifier(location: Location): string | null {
 }
 
 const mapStateToProps = createStructuredSelector({
-  comment: getComment,
-  isLoading: getIsLoading,
   availableTags: getTaggableTags,
   allScores: getScores,
   taggingSensitivities: getTaggingSensitivities,
@@ -116,7 +111,6 @@ function mapDispatchToProps(dispatch: IAppDispatch): ICommentDetailDispatchProps
   return {
     loadData: (commentId: string) => {
       return Promise.all([
-        loadComment(dispatch, commentId),
         loadScores(dispatch, commentId),
       ]);
     },
@@ -129,7 +123,7 @@ function mapDispatchToProps(dispatch: IAppDispatch): ICommentDetailDispatchProps
 
     onUpdateComment: (comment: ICommentModel) => {
       return Promise.all([
-        dispatch(updateComment(comment)),
+        dispatch(commentsUpdated([comment])),
         updateCommentState(dispatch, comment),
       ]); },
 
@@ -147,8 +141,8 @@ function mapDispatchToProps(dispatch: IAppDispatch): ICommentDetailDispatchProps
   };
 }
 
-// Add Redux data.
 export const CommentDetail: React.ComponentClass = compose(
-  connect(mapStateToProps, mapDispatchToProps),
   withRouter,
+  commentFromRouteInjector,
+  connect(mapStateToProps, mapDispatchToProps),
 )(PureCommentDetail);

--- a/packages/frontend-web/src/app/scenes/Comments/components/CommentDetail/store.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/components/CommentDetail/store.ts
@@ -19,25 +19,13 @@ import { combineReducers } from 'redux';
 import { Action, createAction, handleActions } from 'redux-actions';
 
 import {
-  ICommentModel,
   ICommentScoreModel,
-  ITaggingSensitivityModel,
-  ModelId,
 } from '../../../../../models';
 import { IAppDispatch, IAppState } from '../../../../appstate';
 import {
-  getComments,
   getCommentScores,
 } from '../../../../platform/dataService';
-import {
-  ISingleRecordState,
-  makeSingleRecordReducer,
-} from '../../../../util';
 
-const loadCommentStart =
-  createAction('comment-detail/LOAD_COMMENT_START');
-const loadCommentComplete =
-  createAction<object>('comment-detail/LOAD_COMMENT_COMPLETE');
 const loadCommentScoresStart =
   createAction('comment-detail/LOAD_COMMENT_SCORE_START');
 const loadCommentScoresComplete =
@@ -53,28 +41,11 @@ export const clearCommentPagingOptions: () => Action<void> =
 const internalStoreCommentPagingOptions =
   createAction<ICommentPagingState>('comment-detail/STORE_COMMENT_PAGING_OPTIONS');
 
-export async function loadComment(dispatch: IAppDispatch, id: string) {
-  await dispatch(loadCommentStart());
-
-  const [ comment ] = await getComments([id]);
-  await dispatch(loadCommentComplete(comment));
-}
-
 export async function loadScores(dispatch: IAppDispatch, id: string) {
   await dispatch(loadCommentScoresStart());
   const data = await getCommentScores(id);
   await dispatch(loadCommentScoresComplete(data));
 }
-
-const {
-  reducer: commentReducer,
-  updateRecord: updateCommentRecord,
-} = makeSingleRecordReducer<ICommentModel>(
-  loadCommentStart.toString(),
-  loadCommentComplete.toString(),
-);
-
-export const updateComment: (payload: ICommentModel) => Action<ICommentModel> = updateCommentRecord;
 
 export interface ICommentScoreState {
   items: Array<ICommentScoreModel>;
@@ -259,13 +230,11 @@ export function getPreviousCommentId(state: IAppState, currentHash: string, comm
 }
 
 export type ICommentDetailState = Readonly<{
-  comment: ISingleRecordState<ICommentModel>;
   scores: ICommentScoreState;
   paging: ICommentPagingState;
 }>;
 
 export const reducer = combineReducers<ICommentDetailState>({
-  comment: commentReducer,
   scores: commentScoresReducer,
   paging: commentPagingReducer,
 });
@@ -276,18 +245,6 @@ export const addCommentScore: (payload: ICommentScoreModel) => Action<ICommentSc
 export const updateCommentScore: (payload: ICommentScoreModel) => Action<ICommentScoreModel> = updateCommentScoreRecord;
 export const removeCommentScore: (payload: ICommentScoreModel) => Action<ICommentScoreModel> = removeCommentScoreRecord;
 
-export function getComment(state: IAppState) {
-  return state.scenes.comments.commentDetail.comment.item;
-}
-
 export function getScores(state: IAppState) {
   return state.scenes.comments.commentDetail.scores.items;
-}
-
-export function getIsLoading(state: IAppState) {
-  return state.scenes.comments.commentDetail.comment.isFetching;
-}
-
-export function getTaggingSensitivityForTag(taggingSensitivities: List<ITaggingSensitivityModel>, tagId: ModelId) {
-  return taggingSensitivities.find((ts) => ts.tagId === tagId || ts.categoryId === null);
 }

--- a/packages/frontend-web/src/app/stores/appstate.ts
+++ b/packages/frontend-web/src/app/stores/appstate.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { IArticlesState } from './articles';
 import { ICategoriesState } from './categories';
-import { ICommentsState } from './comments';
+import { ICommentsState, INewCommentsState } from './comments';
 import { ICountsState } from './counts';
 import { IPreselectsState } from './preselects';
 import { IRulesState } from './rules';
@@ -30,6 +30,7 @@ export type IGlobalState = Readonly<{
   categories: ICategoriesState;
   articles: IArticlesState;
   comments: ICommentsState;
+  newComments: INewCommentsState;
   counts: ICountsState;
   users: IUsersState;
   tags: ITagsState;

--- a/packages/frontend-web/src/app/stores/commentActions.ts
+++ b/packages/frontend-web/src/app/stores/commentActions.ts
@@ -22,6 +22,7 @@ import {
   confirmCommentSummaryScoreRequest,
   deferCommentsRequest,
   deleteCommentTagRequest,
+  getComments,
   highlightCommentsRequest,
   rejectCommentScoreRequest,
   rejectCommentsRequest,
@@ -34,11 +35,13 @@ import {
   tagCommentsRequest,
   tagCommentSummaryScoresRequest,
 } from '../platform/dataService';
+import {store} from '../store';
+import {commentsUpdated} from './comments';
 
-/**
- * Wrap a bunch of data service calls where we don't care about the result
- * in thunks for redux action dispatching and chaining.
- */
+export async function fetchComments(commentIds: Array<ModelId>) {
+  const comments = await getComments(commentIds);
+  store.dispatch(commentsUpdated(comments));
+}
 
 export async function deleteCommentTag(commentId: ModelId, commentScoreId: string) {
   await deleteCommentTagRequest(commentId, commentScoreId);

--- a/packages/frontend-web/src/app/stores/index.ts
+++ b/packages/frontend-web/src/app/stores/index.ts
@@ -19,7 +19,7 @@ import { combineReducers } from 'redux';
 import { IGlobalState } from './appstate';
 import { reducer as articleReducer } from './articles';
 import { reducer as categoriesReducer } from './categories';
-import { reducer as commentsReducer } from './comments';
+import { newReducer as newCommentsReducer, reducer as commentsReducer } from './comments';
 import { reducer as countsReducer } from './counts';
 import { reducer as preselectsReducer } from './preselects';
 import { reducer as rulesReducer } from './rules';
@@ -33,6 +33,7 @@ export const reducer = combineReducers<IGlobalState>({
   categories: categoriesReducer,
   articles: articleReducer,
   comments: commentsReducer,
+  newComments: newCommentsReducer,
   counts: countsReducer,
   users: usersReducer,
   tags: tagsReducer,

--- a/packages/frontend-web/src/models/comment.ts
+++ b/packages/frontend-web/src/models/comment.ts
@@ -67,7 +67,6 @@ export interface ICommentAttributes {
   categoryId?: ModelId;
   articleId: ModelId;
   replyId?: ModelId;
-  replyTo?: ICommentModel;
   replies?: Array<ICommentModel>;
 
   summaryScores?: Array<ICommentSummaryScoreModel2>;
@@ -80,12 +79,14 @@ export type ICommentModel = Readonly<ICommentAttributes>;
 export function CommentModel(keyValuePairs?: ICommentAttributes): ICommentModel {
   const author: any = (keyValuePairs as ICommentAttributes).author;
 
-  if (author.user_name) {
-    author.name = author.user_name;
-  }
+  if (author) {
+    if (author.user_name) {
+      author.name = author.user_name;
+    }
 
-  if (author.image_uri) {
-    author.avatar = author.image_uri;
+    if (author.image_uri) {
+      author.avatar = author.image_uri;
+    }
   }
 
   const fsd = keyValuePairs.flagsSummary;


### PR DESCRIPTION
This pull request introduces the comment injector, closely modelled on the article injector. 

The comment injector is designed to provide a single coherent store for comment objects.  
 - Comments are loaded into the store on demand.
 - Comments don't need to be refetched when navigating between pages
 - The comment update logic becomes very simple.  
   - Currently, when updating a comment, multiple stores need to be updated.  The existing code to do this is very inconsistent, and I suspect very buggy.
 - We'll eventually be able to handle comment update notifications from the server in the same way we handle article update notifications.
Eventually, the comment injector will replace all other comment and summaryScore stores.

This pull request just uses the comment injector in a couple of places
 - It replaces the comment store for the CommentDetails component.  This illustrates the viability of the approach.
 - It injects the "replyTo" comment into the CommentDetails component as that is no longer provided via the API.

Note: The change to SingleComment looks big, but in reality some code has just been moved into a separate function to make it easier to call it conditionally.
