### PR TITLE
Simplify settings api

### DIFF
--- a/packages/backend-api/src/api/services/simple.ts
+++ b/packages/backend-api/src/api/services/simple.ts
@@ -33,6 +33,10 @@ import {
   CommentSummaryScore,
   ICommentInstance,
   ICommentScoreAttributes,
+  ModerationRule,
+  Preselect,
+  Tag,
+  TaggingSensitivity,
   User,
   USER_GROUP_ADMIN,
   USER_GROUP_GENERAL,
@@ -97,7 +101,7 @@ export function createSimpleRESTService(): express.Router {
       return;
     }
 
-    const group = await user.group;
+    const group = user.group;
 
     function isRealUser(g: string) {
       return g === USER_GROUP_ADMIN || g === USER_GROUP_GENERAL;
@@ -249,5 +253,25 @@ export function createSimpleRESTService(): express.Router {
     next();
   });
 
+  router.delete('/:model/:id', async (req, res, next) => {
+    const objectId = parseInt(req.params.id, 10);
+    switch (req.params.model) {
+      case 'moderation_rules':
+        await ModerationRule.destroy({where: {id: objectId}});
+        break;
+      case 'preselects':
+        await Preselect.destroy({where: {id: objectId}});
+        break;
+      case 'tagging_sensitivities':
+        await TaggingSensitivity.destroy({where: {id: objectId}});
+        break;
+      case 'tags':
+        await Tag.destroy({where: {id: objectId}});
+        break;
+    }
+    updateHappened();
+    res.json(REPLY_SUCCESS);
+    next();
+  });
   return router;
 }

--- a/packages/backend-api/src/models/moderation_rule.ts
+++ b/packages/backend-api/src/models/moderation_rule.ts
@@ -34,6 +34,8 @@ export const MODERATION_RULE_ACTION_TYPES = [
   MODERATION_ACTION_HIGHLIGHT,
 ];
 
+export const MODERATION_RULE_ACTION_TYPES_SET = new Set(MODERATION_RULE_ACTION_TYPES);
+
 export interface IModerationRuleAttributes extends IBaseAttributes {
   tagId: number;
   categoryId?: number;

--- a/packages/frontend-web/package-lock.json
+++ b/packages/frontend-web/package-lock.json
@@ -3131,14 +3131,6 @@
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
 		},
-		"@types/fixed-data-table-2": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/@types/fixed-data-table-2/-/fixed-data-table-2-0.8.3.tgz",
-			"integrity": "sha512-HKd4B91NQvG4dRhi9gYCfFJIbJXeXyHC0MR38o3NiDq8j3qndY/lyRzo05yWMnNNJfX361gu3zBwt8TMF02WDg==",
-			"requires": {
-				"@types/react": "*"
-			}
-		},
 		"@types/glob": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -18376,11 +18368,6 @@
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
 			}
-		},
-		"typed-immutable-record": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typed-immutable-record/-/typed-immutable-record-0.0.6.tgz",
-			"integrity": "sha1-A6wGNqNIGRRPvL4K4u2av2wZqQg="
 		},
 		"typed-styles": {
 			"version": "0.0.7",

--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -111,7 +111,6 @@
     "redux-devtools": "3.5.0",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "slugify": "1.3.6",
-    "typed-immutable-record": "0.0.6"
+    "slugify": "1.3.6"
   }
 }

--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -67,7 +67,6 @@
     "@types/aphrodite": "0.5.13",
     "@types/check-types": "7.3.1",
     "@types/enzyme": "3.10.3",
-    "@types/fixed-data-table-2": "0.8.3",
     "@types/jwt-decode": "2.2.1",
     "@types/keyboardjs": "2.4.1",
     "@types/prop-types": "15.7.3",

--- a/packages/frontend-web/src/app/components/RuleBars/RuleBars.tsx
+++ b/packages/frontend-web/src/app/components/RuleBars/RuleBars.tsx
@@ -71,8 +71,8 @@ function differentiateRules(rules: List<IRuleModel>): Array<IRuleModel> {
   return sortedRules.reduce((sum, currentRule, i, allRules) => {
     const nextRule = allRules[i + 1];
 
-    if (nextRule && currentRule.get('upperThreshold') > nextRule.get('lowerThreshold')) {
-      sum.push(currentRule.set('upperThreshold', nextRule.lowerThreshold));
+    if (nextRule && currentRule.upperThreshold > nextRule.lowerThreshold) {
+      sum.push({ ...currentRule, upperThreshold: nextRule.lowerThreshold});
     } else {
       sum.push(currentRule);
     }

--- a/packages/frontend-web/src/app/components/ScoresList/ScoresList.tsx
+++ b/packages/frontend-web/src/app/components/ScoresList/ScoresList.tsx
@@ -128,7 +128,7 @@ export function ScoresList(props: IScoresListProps) {
   }
 
   const exampleScore = scores[0] || null;
-  const tag = tags && tags.find((t) => (t.get('id') === exampleScore.tagId));
+  const tag = tags && tags.find((t) => (t.id === exampleScore.tagId));
   const scoresAboveThreshold = threshold && scores && scores.filter((score) => score.score >= threshold.lowerThreshold);
   const scoresBelowThreshold = threshold && scores && scores.filter((score) => score.score < threshold.lowerThreshold);
 

--- a/packages/frontend-web/src/app/components/SingleComment/components/AnnotatedCommentText.tsx
+++ b/packages/frontend-web/src/app/components/SingleComment/components/AnnotatedCommentText.tsx
@@ -586,7 +586,7 @@ export class AnnotatedCommentText extends React.PureComponent<IAnnotatedCommentT
     const str = originalString.slice(start, end);
     if (str.length > 0) {
       if (tagId) {
-        const tag = this.props.availableTags.find((t) => (t.get('id') === tagId));
+        const tag = this.props.availableTags.find((t) => (t.id === tagId));
 
         if (author !== 'Machine' && author !== null) {
           status = 'tagged';

--- a/packages/frontend-web/src/app/components/SingleComment/components/CommentTags.tsx
+++ b/packages/frontend-web/src/app/components/SingleComment/components/CommentTags.tsx
@@ -197,7 +197,7 @@ export class CommentTags extends React.PureComponent<ICommentTagsProps, IComment
               return;
             }
 
-            const tag = availableTags.find((t) => (t.get('id') === s.tagId));
+            const tag = availableTags.find((t) => (t.id === s.tagId));
 
             return tag && (
               <button

--- a/packages/frontend-web/src/app/components/SingleComment/components/SummaryScore.tsx
+++ b/packages/frontend-web/src/app/components/SingleComment/components/SummaryScore.tsx
@@ -87,7 +87,7 @@ function SummaryScore(props: ISummaryScoreProps) {
   const {score, withColor, onScoreClick} = props;
   const tags = useSelector(getTags);
 
-  const tag = tags.find((t) => (t.get('id') === score.tagId));
+  const tag = tags.find((t) => (t.id === score.tagId));
   if (!tag) {
     return;
   }

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -398,9 +398,7 @@ export async function destroyModel(
   type: IValidModelNames,
   id: string,
 ): Promise<void> {
-  validateModelName(type);
-
-  await axios.delete(modelURL(type, id));
+  await axios.delete(serviceURL('simple', `/${type}/${id}`));
 }
 
 export async function getCommentScores(commentId: string): Promise<Array<ICommentScoreModel>> {

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -35,6 +35,7 @@ import {
   ICommentModel,
   ICommentScore,
   ICommentScoreModel,
+  ITagModel,
   IUserModel,
   ModelId,
   UserModel,
@@ -46,7 +47,7 @@ export type IValidModelNames =
     'moderation_rules' |
     'preselects' |
     'tagging_sensitivities' |
-    'tags';
+    'tag';
 
 /**
  * Convert Partial<IParams> type to a query string.
@@ -342,9 +343,7 @@ export async function updateArticle(id: string, isCommentingEnabled: boolean, is
   await axios.post(url, {isCommentingEnabled, isAutoModerated});
 }
 
-export async function createUser(user: IUserModel) {
-  const url = serviceURL('simple', `/user`);
-  const attributes = pick(user, ['name', 'email', 'group', 'isActive']);
+async function createThing(url: string, attributes: {[key: string]: string | number | boolean}) {
   try {
     await axios.post(url, attributes);
   } catch (e) {
@@ -355,10 +354,41 @@ export async function createUser(user: IUserModel) {
   }
 }
 
+async function updateThing(url: string, attributes: {[key: string]: string | number | boolean}) {
+  try {
+    await axios.patch(url, attributes);
+  } catch (e) {
+    if (e.response) {
+      throw new Error(e.response.data);
+    }
+    throw e;
+  }
+}
+
+export async function createUser(user: IUserModel) {
+  const url = serviceURL('simple', `/user`);
+  const attributes = pick(user, ['name', 'email', 'group', 'isActive']);
+  return createThing(url, attributes);
+}
+
+export async function createTag(tag: ITagModel) {
+  const url = serviceURL('simple', `/tag`);
+  const attributes = pick(tag, ['color', 'description', 'key', 'label',
+    'isInBatchView', 'inSummaryScore', 'isTaggable']);
+  return createThing(url, attributes);
+}
+
 export async function updateUser(user: IUserModel) {
   const url = serviceURL('simple', `/user/update/${user.id}`);
   const attributes = pick(user, ['name', 'email', 'group', 'isActive']);
   await axios.post(url, attributes);
+}
+
+export async function updateTag(tag: ITagModel) {
+  const url = serviceURL('simple', `/tag/${tag.id}`);
+  const attributes = pick(tag, ['color', 'description', 'key', 'label',
+    'isInBatchView', 'inSummaryScore', 'isTaggable']);
+  return updateThing(url, attributes);
 }
 
 /**

--- a/packages/frontend-web/src/app/platform/dataService.ts
+++ b/packages/frontend-web/src/app/platform/dataService.ts
@@ -15,12 +15,11 @@ limitations under the License.
 */
 
 import axios from 'axios';
-import { fromJS, List } from 'immutable';
+import { List } from 'immutable';
 import { pick } from 'lodash';
 import qs from 'qs';
 
 import {
-  INewResource,
   IParams,
 } from './types';
 
@@ -117,11 +116,11 @@ function modelURL(type: IValidModelNames, id: string): string {
  */
 export async function createModel(
   type: IValidModelNames,
-  model: INewResource,
+  model: {id: ModelId, [key: string]: string | number | boolean},
 ): Promise<void> {
   await axios.post(listURL(type), {
     data: {
-      attributes: fromJS(model).delete('id').toJS(),
+      attributes: model,
       type,
     },
   });
@@ -327,21 +326,13 @@ export async function getArticleText(id: ModelId) {
  */
 export async function updateModel(
   type: IValidModelNames,
-  id: string,
-  model: INewResource,
-  onlyAttributes?: Array<string>,
+  model: {id: ModelId, [key: string]: string | number | boolean},
 ): Promise<void> {
-  let attributes = fromJS(model).delete('id').toJS();
-
-  if (onlyAttributes) {
-    attributes = pick(attributes, onlyAttributes);
-  }
-
-  await axios.patch(modelURL(type, id), {
+  await axios.patch(modelURL(type, model.id), {
     data: {
-      attributes,
+      attributes: model,
       type,
-      id,
+      id: model.id,
     },
   });
 }

--- a/packages/frontend-web/src/app/platform/types.ts
+++ b/packages/frontend-web/src/app/platform/types.ts
@@ -14,67 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export type IResourceID = string | number;
-
-export interface IWithID {
-  id: IResourceID;
-}
-
-export interface IResourceType {
-  type: string;
-}
-
-export interface IResourceIdentifier extends IWithID, IResourceType {
-}
-
-export interface IAttributes {
-  [name: string]: any;
-}
-
-export interface ILinks {
-  [name: string]: string;
-}
-
-export interface IResourceSpecifics {
-  attributes: IAttributes;
-  relationships?: IRelationships;
-  links?: ILinks;
-}
-
-export interface INewResource extends IResourceType, IResourceSpecifics {
-}
-
-export interface IResourceComplete extends IResourceIdentifier, IResourceSpecifics {
-  [key: string]: any;
-}
-
-export type IResource = IResourceComplete | IResourceIdentifier;
-
-export type IData = IResource | Array<IResource>; // Or empty array, null
-
-export type IRelationship = IData;
-
-export interface IEmbeddedRelationship {
-  data: IRelationship;
-  links: ILinks;
-}
-
-export interface IRelationships {
-  [name: string]: IEmbeddedRelationship;
-}
-
-export interface IListDetails {
-  totalItems: number;
-  pageItems: Array<IResource>;
-  includes?: Array<IResourceComplete>;
-  extra?: any;
-}
-
-export interface IItemDetails {
-  item: IResource;
-  includes?: Array<IResourceComplete>;
-}
-
 export interface IPagingParams {
   limit?: number;
   offset?: number;
@@ -94,9 +33,4 @@ export interface IParams {
   filters: IFilters;
   sort: Array<string>;
   fields: IFields;
-}
-
-export interface IStatusError {
-  error: number;
-  message?: string;
 }

--- a/packages/frontend-web/src/app/scenes/Comments/components/NewComments/store/util.ts
+++ b/packages/frontend-web/src/app/scenes/Comments/components/NewComments/store/util.ts
@@ -30,10 +30,11 @@ import { getTags } from '../../../../../stores/tags';
 import { groupByDateColumns } from '../../../../../util';
 
 const dateTag = TagModel({
+  id: 'DATE',
   label: 'All Comments by Date',
   key: 'DATE',
   color: '',
-}).set('id', 'DATE');
+});
 
 export function getTagsWithDateAndSummary(state: IAppState): List<ITagModel> {
   return getTags(state).push(dateTag);

--- a/packages/frontend-web/src/app/scenes/Comments/components/TagSelector/TagSelector.tsx
+++ b/packages/frontend-web/src/app/scenes/Comments/components/TagSelector/TagSelector.tsx
@@ -77,10 +77,11 @@ const SNAPSHOT_WIDTH = 264;
 const SNAPSHOT_HEIGHT = 76;
 
 const dateTag = TagModel({
+  id: 'DATE',
   label: 'All Comments by Date',
   key: 'DATE',
   color: '',
-}).set('id', 'DATE');
+});
 
 function getImagePath(base: string, id: string, tagId: string) {
   const dp = window.devicePixelRatio || 1;

--- a/packages/frontend-web/src/app/scenes/Settings/components/ManageAutomatedRules.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/ManageAutomatedRules.tsx
@@ -85,19 +85,20 @@ export function ManageAutomatedRules(props: {
 
   function handleAutomatedRuleChange(category: string, rule: IRuleModel, value: number | string) {
     setRules(rules.update(
-      rules.findIndex((r) => r.equals(rule)),
-      (r) => r.set(category, value),
+      rules.findIndex((r) => r.id === rule.id),
+      (r) => ({...r, [category]: value}),
       ));
   }
 
   function handleAutomatedRuleDelete(rule: IRuleModel) {
-    setRules(rules.delete(rules.findIndex((r) => r.equals(rule))));
+    setRules(rules.delete(rules.findIndex((r) => r.id === rule.id)));
   }
 
   function handleModerateButtonClick(rule: IRuleModel, action: IServerAction) {
     const updatedRules = rules.update(
-      rules.findIndex(((r) => r.equals(rule))),
-      (r) => r.set('action', action));
+      rules.findIndex(((r) => r.id === rule.id)),
+      (r) => ({...r, action}),
+    );
     setRules(updatedRules);
   }
 
@@ -119,7 +120,7 @@ export function ManageAutomatedRules(props: {
     <form {...css(STYLES.formContainer)}>
       <div key="editRulesSection">
         <div key="heading" {...css(SETTINGS_STYLES.heading)}>
-          <h2 {...css(SETTINGS_STYLES.headingText)}>Automated Rules</h2>
+          <h2 {...css(SETTINGS_STYLES.headingText)}>Automated Rules <small>(The server will automatically pass/fail comments that match these filters)</small></h2>
         </div>
         <div key="body" {...css(SETTINGS_STYLES.section)}>
           {rules && rules.map((rule, i) => (

--- a/packages/frontend-web/src/app/scenes/Settings/components/ManagePreselects.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/ManagePreselects.tsx
@@ -71,14 +71,14 @@ export function ManagePreselects(props: {
 
   function handlePreselectChange(category: string, preselect: IPreselectModel, value: number | string) {
     setPreselects(preselects.update(
-      preselects.findIndex((r) => r.equals(preselect)),
-      (r) => r.set(category, value),
+      preselects.findIndex((r) => r.id === preselect.id),
+      (r) => ({...r, [category]: value}),
     ));
   }
 
   function handlePreselectDelete(preselect: IPreselectModel) {
     setPreselects(
-      preselects.delete(preselects.findIndex((r) => r.equals(preselect))),
+      preselects.delete(preselects.findIndex((r) => r.id === preselect.id)),
     );
   }
 
@@ -122,7 +122,7 @@ export function ManagePreselects(props: {
       <div key="editRangesSection">
         <div key="heading" {...css(SETTINGS_STYLES.heading)}>
           <h2 {...css(SETTINGS_STYLES.headingText)}>
-            Preselected Batch Ranges (sets the default score range on a per category basis for tags in the batch selection view)
+            New Comments Page: Preselected Ranges <small>(Controls range of scores to show when first visiting the New Comments page)</small>
           </h2>
         </div>
         <div key="body" {...css(SETTINGS_STYLES.section)}>

--- a/packages/frontend-web/src/app/scenes/Settings/components/ManageSensitivities.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/ManageSensitivities.tsx
@@ -95,14 +95,14 @@ export function ManageSensitivities(props: {
 
   function handleTaggingSensitivityChange(category: string, ts: ITaggingSensitivityModel, value: number | string) {
     setSensitivities(sensitivities.update(
-      sensitivities.findIndex((r) => r.equals(ts)),
-      (r) => r.set(category, value),
+      sensitivities.findIndex((r) => r.id === ts.id),
+      (r) => ({...r, [category]: value}),
     ));
   }
 
   function handleTaggingSensitivityDelete(ts: ITaggingSensitivityModel) {
     setSensitivities(sensitivities.delete(
-      sensitivities.findIndex((r) => r.equals(ts)),
+      sensitivities.findIndex((r) => r.id === ts.id),
     ));
   }
 
@@ -124,7 +124,7 @@ export function ManageSensitivities(props: {
     <form {...css(STYLES.formContainer)}>
       <div key="editSensitivitiesSection">
         <div key="heading" {...css(SETTINGS_STYLES.heading)}>
-          <h2 {...css(SETTINGS_STYLES.headingText)}>Tagging Sensitivity (determines at what score range a tag will appear in the UI)</h2>
+          <h2 {...css(SETTINGS_STYLES.headingText)}>Sensitivity <small>(The range where a score become interesting. Scores that match these ranges are highlighted in the UI)</small></h2>
         </div>
         <div key="body" {...css(SETTINGS_STYLES.section)}>
           {sensitivities && sensitivities.map((ts, i) => (

--- a/packages/frontend-web/src/app/scenes/Settings/components/ManageTags.tsx
+++ b/packages/frontend-web/src/app/scenes/Settings/components/ManageTags.tsx
@@ -93,15 +93,15 @@ export function ManageTags(props: {
 
   function handleLabelChange(tag: ITagModel, value: string) {
     setTags(tags.update(
-      tags.findIndex((t) => t.equals(tag)),
-      (t) => t.set('label', value),
+      tags.findIndex((t) => t.id === tag.id),
+      (t) => ({...t, label: value}),
     ));
   }
 
   function handleDescriptionChange(tag: ITagModel, value: string) {
     setTags(tags.update(
-      tags.findIndex((t) => t.equals(tag)),
-      (t) => t.set('description', value),
+      tags.findIndex((t) =>  t.id === tag.id),
+      (t) => ({...t, description: value}),
     ));
   }
 
@@ -111,13 +111,13 @@ export function ManageTags(props: {
     }
 
     setTags(tags.update(
-      tags.findIndex((t) => t.equals(tag)),
-      (t) => t.set('color', color),
+      tags.findIndex((t) =>  t.id === tag.id),
+      (t) => ({...t, color}),
     ));
   }
 
   function handleTagDeletePress(tag: ITagModel) {
-    setTags(tags.delete(tags.findIndex((t) => t.equals(tag))));
+    setTags(tags.delete(tags.findIndex((t) =>  t.id === tag.id)));
   }
 
   function handleTagChange(
@@ -126,8 +126,8 @@ export function ManageTags(props: {
     value: boolean,
   ) {
     setTags(tags.update(
-      tags.findIndex((t) => t.equals(tag)),
-      (t) => t.set(key, value),
+      tags.findIndex((t) =>  t.id === tag.id),
+      (t) => ({...t, [key]: value}),
     ));
   }
 

--- a/packages/frontend-web/src/app/scenes/Settings/store.ts
+++ b/packages/frontend-web/src/app/scenes/Settings/store.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../models';
 import {
   createModel,
+  createUser,
   destroyModel,
   updateModel,
   updateUser,
@@ -49,11 +50,7 @@ function diff<T extends Map<string, any>>(original: List<T>, current: List<T>): 
 }
 
 export async function addUser(user: IUserModel): Promise<void> {
-  // TODO: Don't know what's going on with the types here (hence the cast to any), nor with the key field...
-  await createModel(
-    'users',
-    {...user, key: slugify(user.name, '_').toUpperCase()} as any,
-  );
+  await createUser(user);
 }
 
 // TODO: the typing in this module looks wrong - note the many casts to 'any' when calling createModel, updateModel etc.

--- a/packages/frontend-web/src/app/scenes/Settings/store.ts
+++ b/packages/frontend-web/src/app/scenes/Settings/store.ts
@@ -27,11 +27,15 @@ import {
   ModelId,
 } from '../../../models';
 import {
-  createModel,
+  createPreselect,
+  createRule,
+  createSensitivity,
   createTag,
   createUser,
   destroyModel,
-  updateModel,
+  updatePreselect,
+  updateRule,
+  updateSensitivity,
   updateTag,
   updateUser,
 } from '../../platform/dataService';
@@ -94,15 +98,15 @@ export async function updateTags(oldTags: List<ITagModel>, newTags: List<ITagMod
 }
 
 async function addRule(rule: IRuleModel): Promise<void> {
-  await createModel('moderation_rules', rule);
+  await createRule(rule);
 }
 
 async function modifyRule(rule: IRuleModel): Promise<void> {
-  await updateModel('moderation_rules', rule);
+  await updateRule(rule);
 }
 
 async function deleteRule(ruleId: ModelId): Promise<void> {
-  await destroyModel('moderation_rules', ruleId);
+  await destroyModel('moderation_rule', ruleId);
 }
 
 export async function updateRules(oldRules: List<IRuleModel>, newRules: List<IRuleModel>) {
@@ -115,15 +119,15 @@ export async function updateRules(oldRules: List<IRuleModel>, newRules: List<IRu
 }
 
 async function addPreselect(preselect: IPreselectModel): Promise<void> {
-  await createModel('preselects', preselect);
+  await createPreselect(preselect);
 }
 
 async function modifyPreselect(preselect: IPreselectModel): Promise<void> {
-  await updateModel('preselects', preselect);
+  await updatePreselect(preselect);
 }
 
 async function deletePreselect(preselectId: ModelId): Promise<void> {
-  await destroyModel('preselects', preselectId);
+  await destroyModel('preselect', preselectId);
 }
 
 export async function updatePreselects(oldPreselects: List<IPreselectModel>, newPreselects: List<IPreselectModel>) {
@@ -136,15 +140,15 @@ export async function updatePreselects(oldPreselects: List<IPreselectModel>, new
 }
 
 async function addTaggingSensitivity(taggingSensitivity: ITaggingSensitivityModel): Promise<void> {
-  await createModel('tagging_sensitivities', taggingSensitivity);
+  await createSensitivity(taggingSensitivity);
 }
 
 async function modifyTaggingSensitivity(taggingSensitivity: ITaggingSensitivityModel): Promise<void> {
-  await updateModel('tagging_sensitivities', taggingSensitivity);
+  await updateSensitivity(taggingSensitivity);
 }
 
 async function deleteTaggingSensitivity(taggingSensitivityId: ModelId): Promise<void> {
-  await destroyModel('tagging_sensitivities', taggingSensitivityId);
+  await destroyModel('tagging_sensitivity', taggingSensitivityId);
 }
 
 export async function updateTaggingSensitivities(oldRules: List<ITaggingSensitivityModel>, newRules: List<ITaggingSensitivityModel>) {

--- a/packages/frontend-web/src/app/scenes/Settings/store.ts
+++ b/packages/frontend-web/src/app/scenes/Settings/store.ts
@@ -28,9 +28,11 @@ import {
 } from '../../../models';
 import {
   createModel,
+  createTag,
   createUser,
   destroyModel,
   updateModel,
+  updateTag,
   updateUser,
 } from '../../platform/dataService';
 
@@ -68,18 +70,18 @@ export async function modifyUser(user: IUserModel): Promise<void> {
 }
 
 async function addTag(tag: ITagModel): Promise<void> {
-  await createModel('tags', {
+  await createTag({
     ...tag,
     key: slugify(tag.label, '_').toUpperCase(),
   });
 }
 
 async function modifyTag(tag: ITagModel): Promise<void> {
-  await updateModel('tags', tag);
+  await updateTag(tag);
 }
 
 async function deleteTag(tagId: ModelId): Promise<void> {
-  await destroyModel('tags', tagId);
+  await destroyModel('tag', tagId);
 }
 
 export async function updateTags(oldTags: List<ITagModel>, newTags: List<ITagModel>) {

--- a/packages/frontend-web/src/models/preselect.ts
+++ b/packages/frontend-web/src/models/preselect.ts
@@ -14,29 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Record } from 'immutable';
-import { TypedRecord } from 'typed-immutable-record';
-
 import { ModelId } from './common';
 
 export interface IPreselectAttributes {
-  id: string;
+  id: ModelId;
   categoryId?: ModelId;
   lowerThreshold: number;
   upperThreshold: number;
   tagId?: ModelId;
 }
 
-export interface IPreselectModel extends TypedRecord<IPreselectModel>, IPreselectAttributes {}
+export type IPreselectModel = Readonly<IPreselectAttributes>;
 
-const PreselectModelRecord = Record({
-  id: null,
-  categoryId: null,
-  lowerThreshold: null,
-  upperThreshold: null,
-  tagId: null,
-});
-
-export function PreselectModel(keyValuePairs?: IPreselectAttributes): IPreselectModel {
-  return new PreselectModelRecord(keyValuePairs) as IPreselectModel;
+export function PreselectModel(keyValuePairs: IPreselectAttributes): IPreselectModel {
+  return keyValuePairs as IPreselectModel;
 }

--- a/packages/frontend-web/src/models/rule.ts
+++ b/packages/frontend-web/src/models/rule.ts
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Record } from 'immutable';
-import { TypedRecord } from 'typed-immutable-record';
-
 import { IServerAction, ModelId } from './common';
 
 export interface IRuleAttributes {
@@ -29,18 +26,8 @@ export interface IRuleAttributes {
   tagId?: ModelId;
 }
 
-export interface IRuleModel extends TypedRecord<IRuleModel>, IRuleAttributes {}
+export type IRuleModel = Readonly<IRuleAttributes>;
 
-const RuleModelRecord = Record({
-  id: null,
-  action: null,
-  categoryId: null,
-  createdBy: null,
-  lowerThreshold: null,
-  upperThreshold: null,
-  tagId: null,
-});
-
-export function RuleModel(keyValuePairs?: IRuleAttributes): IRuleModel {
-  return new RuleModelRecord(keyValuePairs) as IRuleModel;
+export function RuleModel(keyValuePairs: IRuleAttributes): IRuleModel {
+  return keyValuePairs as IRuleModel;
 }

--- a/packages/frontend-web/src/models/tag.ts
+++ b/packages/frontend-web/src/models/tag.ts
@@ -14,11 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Record } from 'immutable';
-import { TypedRecord } from 'typed-immutable-record';
+import {ModelId} from './common';
 
 export interface ITagAttributes {
-  id: string;
+  id: ModelId;
   color: string;
   description: string;
   key: string;
@@ -28,19 +27,8 @@ export interface ITagAttributes {
   isTaggable: boolean;
 }
 
-export interface ITagModel extends TypedRecord<ITagModel>, ITagAttributes {}
+export type ITagModel = Readonly<ITagAttributes>;
 
-const TagModelRecord = Record({
-  id: null,
-  color: null,
-  description: null,
-  key: null,
-  label: null,
-  isInBatchView: false,
-  inSummaryScore: false,
-  isTaggable: false,
-});
-
-export function TagModel(keyValuePairs?: Partial<ITagAttributes>): ITagModel {
-  return new TagModelRecord(keyValuePairs) as ITagModel;
+export function TagModel(keyValuePairs: Partial<ITagAttributes>): ITagModel {
+  return keyValuePairs as ITagModel;
 }

--- a/packages/frontend-web/src/models/taggingSensitivity.ts
+++ b/packages/frontend-web/src/models/taggingSensitivity.ts
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Record } from 'immutable';
-import { TypedRecord } from 'typed-immutable-record';
-
 import { ModelId } from './common';
 
 export interface ITaggingSensitivityAttributes {
@@ -27,16 +24,8 @@ export interface ITaggingSensitivityAttributes {
   tagId?: ModelId;
 }
 
-export interface ITaggingSensitivityModel extends TypedRecord<ITaggingSensitivityModel>, ITaggingSensitivityAttributes {}
+export type ITaggingSensitivityModel = Readonly<ITaggingSensitivityAttributes>;
 
-const TaggingSensitivityModelRecord = Record({
-  id: null,
-  categoryId: null,
-  lowerThreshold: null,
-  upperThreshold: null,
-  tagId: null,
-});
-
-export function TaggingSensitivityModel(keyValuePairs?: ITaggingSensitivityAttributes): ITaggingSensitivityModel {
-  return new TaggingSensitivityModelRecord(keyValuePairs) as ITaggingSensitivityModel;
+export function TaggingSensitivityModel(keyValuePairs: ITaggingSensitivityAttributes): ITaggingSensitivityModel {
+  return keyValuePairs as ITaggingSensitivityModel;
 }

--- a/packages/frontend-web/src/models/user.ts
+++ b/packages/frontend-web/src/models/user.ts
@@ -19,7 +19,6 @@ import { ModelId } from './common';
 export interface IUserAttributes {
   id?: ModelId;
   name: string;
-  key?: string;
   email?: string;
   avatarURL?: string;
   group: string;

--- a/packages/frontend-web/tooling/storybook/preview-head.html
+++ b/packages/frontend-web/tooling/storybook/preview-head.html
@@ -1,5 +1,4 @@
 <link rel="stylesheet" href="/css/normalize.css">
-<link rel="stylesheet" href="/css/fixed-data-table-base.css">
 <link rel="stylesheet" href="/css/fonts/fonts.css">
 <link rel="stylesheet" href="/css/moderator.css">
 <style>


### PR DESCRIPTION
This pull request aims to simplify the settings API, replacing the last remaining uses of the rest/jsonapi API with simple equivalents.  

The APIs in question are:
- Add a user
- Add/Edit/Delete tags
- Add/Edit/Delete the range objects (ModerationRule, Preselect, TaggingSensitivity)

Once these changes are in place, we will be free to delete the rest/jsonapi completely.

It also allows us to apply much better error checking on object creation and update.  This is particularly relevant for "User" objects where the constraints are too complex to implement in the generic code.  E.g., human users require an email address.

This changeset also includes the removal of TypedRecord, another small step in removing legacy and obsolete dependencies from the project.



